### PR TITLE
feat(web): apply draft events sequentially

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
       "name": "@fantasy-oscars/web",
       "dependencies": {
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
feat(web): apply draft events sequentially\nCloses #45