### PR TITLE
feat(api): ceremony winners table + global draft lock marker

### DIFF
--- a/db/migrations/011_ceremony_winners_and_draft_lock.sql
+++ b/db/migrations/011_ceremony_winners_and_draft_lock.sql
@@ -1,0 +1,35 @@
+-- MVP-011 FO-004: ceremony winners table + global draft lock marker
+
+BEGIN;
+
+ALTER TABLE ceremony
+  ADD COLUMN draft_locked_at TIMESTAMPTZ NULL;
+
+CREATE TABLE ceremony_winner (
+  id BIGSERIAL PRIMARY KEY,
+  ceremony_id BIGINT NOT NULL REFERENCES ceremony(id) ON DELETE CASCADE,
+  category_edition_id BIGINT NOT NULL REFERENCES category_edition(id) ON DELETE CASCADE,
+  nomination_id BIGINT NOT NULL REFERENCES nomination(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Only one winner per category edition.
+CREATE UNIQUE INDEX uniq_ceremony_winner_category ON ceremony_winner (category_edition_id);
+CREATE INDEX idx_ceremony_winner_ceremony ON ceremony_winner (ceremony_id);
+
+-- Keep updated_at fresh on updates.
+CREATE OR REPLACE FUNCTION touch_ceremony_winner_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_touch_ceremony_winner_updated_at
+  BEFORE UPDATE ON ceremony_winner
+  FOR EACH ROW
+  EXECUTE FUNCTION touch_ceremony_winner_updated_at();
+
+COMMIT;

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -12,6 +12,7 @@
 - League membership: invite-only per season for MVP; the legacy `POST /leagues/:id/join` endpoint is disabled and returns `INVITE_ONLY_MEMBERSHIP`.
 - League creation: creating a league automatically creates the initial EXTANT season for the active ceremony and adds the creator as OWNER/member in the same transaction.
 - Additional seasons: commissioners can add a new EXTANT season for the active ceremony (one per ceremony). Season lists include an `is_active_ceremony` marker; season creation is blocked if no active ceremony or an extant season already exists for that ceremony.
+- Ceremony winners: `ceremony_winner` stores the winning `nomination_id` per `category_edition` (unique). `ceremony.draft_locked_at` records when winners entry begins; it is set once and never unlocked in MVP.
 
 ## Principles
 


### PR DESCRIPTION
feat(api): ceremony winners table + global draft lock marker

Closes #147
