### PR TITLE
feat(api): draft mutation gates: enforce active ceremony + winner-lock across start/pick

### DIFF
--- a/apps/api/test/routes/draft-submit-pick.integration.test.ts
+++ b/apps/api/test/routes/draft-submit-pick.integration.test.ts
@@ -117,6 +117,78 @@ describe("draft submit pick integration", () => {
     expect(rows[0].count).toBe(0);
   });
 
+  it("rejects pick submission when ceremony is draft-locked (winners entered)", async () => {
+    const league = await insertLeague(db.pool, { roster_size: 1 });
+    await insertUser(db.pool, { id: 1 });
+    const member = await insertLeagueMember(db.pool, {
+      league_id: league.id,
+      user_id: 1
+    });
+    const draft = await insertDraft(db.pool, {
+      league_id: league.id,
+      status: "IN_PROGRESS",
+      current_pick_number: 1
+    });
+    await insertDraftSeat(db.pool, {
+      draft_id: draft.id,
+      league_member_id: member.id,
+      seat_number: 1
+    });
+    const nomination = await insertNomination(db.pool, {
+      ceremony_id: league.ceremony_id
+    });
+    await db.pool.query(`UPDATE app_config SET active_ceremony_id = $1`, [
+      league.ceremony_id
+    ]);
+    await db.pool.query(`UPDATE ceremony SET draft_locked_at = now() WHERE id = $1`, [
+      league.ceremony_id
+    ]);
+
+    const res = await post<{ error: { code: string } }>(`/drafts/${draft.id}/picks`, {
+      nomination_id: nomination.id,
+      request_id: "locked-1"
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.json.error.code).toBe("DRAFT_LOCKED");
+  });
+
+  it("rejects pick submission when season is cancelled", async () => {
+    const league = await insertLeague(db.pool, { roster_size: 1 });
+    await insertUser(db.pool, { id: 1 });
+    const member = await insertLeagueMember(db.pool, {
+      league_id: league.id,
+      user_id: 1
+    });
+    const draft = await insertDraft(db.pool, {
+      league_id: league.id,
+      status: "IN_PROGRESS",
+      current_pick_number: 1
+    });
+    await insertDraftSeat(db.pool, {
+      draft_id: draft.id,
+      league_member_id: member.id,
+      seat_number: 1
+    });
+    const nomination = await insertNomination(db.pool, {
+      ceremony_id: league.ceremony_id
+    });
+    await db.pool.query(`UPDATE app_config SET active_ceremony_id = $1`, [
+      league.ceremony_id
+    ]);
+    await db.pool.query(`UPDATE season SET status = 'CANCELLED' WHERE id = $1`, [
+      draft.season_id
+    ]);
+
+    const res = await post<{ error: { code: string } }>(`/drafts/${draft.id}/picks`, {
+      nomination_id: nomination.id,
+      request_id: "cancelled-1"
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.json.error.code).toBe("SEASON_CANCELLED");
+  });
+
   it("rejects invalid payloads", async () => {
     const draft = await insertDraft(db.pool, {
       status: "IN_PROGRESS",

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -11,6 +11,7 @@
 - Seasons: `season` links a league to a ceremony; at most one EXTANT season per (league, ceremony); drafts belong to a season (one draft per season).
 - Draft start freezes sizing: `draft.picks_per_seat = floor(draft-eligible nominations for the ceremony / participant count)` is computed at `POST /drafts/:id/start`, stored on the draft, and used for completion; any remainder nominations stay undrafted for MVP.
 - Draft status can be paused by commissioners; `status=PAUSED` blocks picks, surfaces in snapshots, and is reversible via resume.
+- Draft actions (start/pick) are only allowed for the active ceremony while the ceremony is unlocked and the season is EXTANT; once `ceremony.draft_locked_at` is set (winners entered) or the season is CANCELLED, start/picks are blocked.
 - League membership: invite-only per season for MVP; the legacy `POST /leagues/:id/join` endpoint is disabled and returns `INVITE_ONLY_MEMBERSHIP`.
 - League creation: creating a league automatically creates the initial EXTANT season for the active ceremony and adds the creator as OWNER/member in the same transaction.
 - Additional seasons: commissioners can add a new EXTANT season for the active ceremony (one per ceremony). Season lists include an `is_active_ceremony` marker; season creation is blocked if no active ceremony or an extant season already exists for that ceremony.


### PR DESCRIPTION
feat(api): draft mutation gates: enforce active ceremony + winner-lock across start/pick

Closes #164
