### PR TITLE
feat(api): results + standings derived from ceremony winners (not per-draft ad hoc)

### DIFF
--- a/apps/api/src/routes/drafts.test.ts
+++ b/apps/api/src/routes/drafts.test.ts
@@ -15,6 +15,7 @@ import { AppError } from "../errors.js";
 import * as draftRepo from "../data/repositories/draftRepository.js";
 import * as leagueRepo from "../data/repositories/leagueRepository.js";
 import * as seasonRepo from "../data/repositories/seasonRepository.js";
+import * as winnerRepo from "../data/repositories/winnerRepository.js";
 import { requireAuth } from "../auth/middleware.js";
 import type { DbClient } from "../data/db.js";
 import * as db from "../data/db.js";
@@ -687,7 +688,8 @@ describe("GET /drafts/:id/standings", () => {
   const getDraftByIdSpy = vi.spyOn(draftRepo, "getDraftById");
   const listDraftSeatsSpy = vi.spyOn(draftRepo, "listDraftSeats");
   const listDraftPicksSpy = vi.spyOn(draftRepo, "listDraftPicks");
-  const listDraftResultsSpy = vi.spyOn(draftRepo, "listDraftResults");
+  const getSeasonByIdSpy = vi.spyOn(seasonRepo, "getSeasonById");
+  const listWinnersByCeremonySpy = vi.spyOn(winnerRepo, "listWinnersByCeremony");
   const handler = buildDraftStandingsHandler({} as unknown as Pool);
 
   beforeEach(() => {
@@ -745,22 +747,18 @@ describe("GET /drafts/:id/standings", () => {
         made_at: new Date("2024-01-01T00:11:00Z")
       }
     ]);
-    listDraftResultsSpy.mockResolvedValue([
+    getSeasonByIdSpy.mockResolvedValue({
+      id: 500,
+      league_id: 5,
+      ceremony_id: 99,
+      status: "EXTANT",
+      scoring_strategy_name: "fixed",
+      created_at: new Date("2024-01-01T00:00:00Z")
+    });
+    listWinnersByCeremonySpy.mockResolvedValue([
       {
-        draft_id: 77,
-        nomination_id: 200,
-        won: true,
-        points: null,
-        created_at: new Date("2024-01-01T00:30:00Z"),
-        updated_at: new Date("2024-01-01T00:30:00Z")
-      },
-      {
-        draft_id: 77,
-        nomination_id: 201,
-        won: false,
-        points: null,
-        created_at: new Date("2024-01-01T00:30:00Z"),
-        updated_at: new Date("2024-01-01T00:30:00Z")
+        category_edition_id: 123,
+        nomination_id: 200
       }
     ]);
   });

--- a/apps/api/test/routes/draft-standings.scoring.integration.test.ts
+++ b/apps/api/test/routes/draft-standings.scoring.integration.test.ts
@@ -8,6 +8,8 @@ import {
   insertDraftPick,
   insertDraftSeat,
   insertLeague,
+  insertCeremonyWinner,
+  insertCategoryEdition,
   insertNomination,
   insertSeason
 } from "../factories/db.js";
@@ -83,11 +85,11 @@ describe("draft standings scoring strategies", () => {
       round_number: 1,
       nomination_id: nomLose.id
     });
-    await db.pool.query(
-      `INSERT INTO draft_result (draft_id, nomination_id, won, points)
-       VALUES ($1,$2,true,1), ($1,$3,false,1)`,
-      [draftFixed.id, nomWin.id, nomLose.id]
-    );
+    await insertCeremonyWinner(db.pool, {
+      ceremony_id: leagueFixed.ceremony_id,
+      category_edition_id: nomWin.category_edition_id,
+      nomination_id: nomWin.id
+    });
 
     const fixedRes = await getJson<{
       standings: Array<{ seat_number: number; points: number }>;
@@ -141,11 +143,11 @@ describe("draft standings scoring strategies", () => {
       round_number: 1,
       nomination_id: nomLose2.id
     });
-    await db.pool.query(
-      `INSERT INTO draft_result (draft_id, nomination_id, won, points)
-       VALUES ($1,$2,true,1), ($1,$3,false,1)`,
-      [draftNeg.id, nomWin2.id, nomLose2.id]
-    );
+    await insertCeremonyWinner(db.pool, {
+      ceremony_id: leagueNeg.ceremony_id,
+      category_edition_id: nomWin2.category_edition_id,
+      nomination_id: nomWin2.id
+    });
 
     const negRes = await getJson<{
       standings: Array<{ seat_number: number; points: number }>;
@@ -156,5 +158,88 @@ describe("draft standings scoring strategies", () => {
     );
     expect(negPoints.get(1)).toBe(1);
     expect(negPoints.get(2)).toBe(-1);
+  });
+
+  it("recomputes standings when ceremony winners change", async () => {
+    const league = await insertLeague(db.pool);
+    const season = await insertSeason(db.pool, {
+      league_id: league.id,
+      ceremony_id: league.ceremony_id,
+      scoring_strategy_name: "fixed"
+    });
+    const draft = await insertDraft(db.pool, {
+      league_id: league.id,
+      season_id: season.id,
+      status: "COMPLETED"
+    });
+    const seat1 = await insertDraftSeat(db.pool, {
+      draft_id: draft.id,
+      seat_number: 1
+    });
+    const seat2 = await insertDraftSeat(db.pool, {
+      draft_id: draft.id,
+      seat_number: 2
+    });
+
+    const category = await insertCategoryEdition(db.pool, {
+      ceremony_id: league.ceremony_id
+    });
+    const nominationA = await insertNomination(db.pool, {
+      category_edition_id: category.id,
+      ceremony_id: league.ceremony_id
+    });
+    const nominationB = await insertNomination(db.pool, {
+      category_edition_id: category.id,
+      ceremony_id: league.ceremony_id
+    });
+
+    await insertDraftPick(db.pool, {
+      draft_id: draft.id,
+      seat_number: 1,
+      league_member_id: seat1.league_member_id,
+      pick_number: 1,
+      round_number: 1,
+      nomination_id: nominationA.id
+    });
+    await insertDraftPick(db.pool, {
+      draft_id: draft.id,
+      seat_number: 2,
+      league_member_id: seat2.league_member_id,
+      pick_number: 2,
+      round_number: 1,
+      nomination_id: nominationB.id
+    });
+
+    await insertCeremonyWinner(db.pool, {
+      ceremony_id: league.ceremony_id,
+      category_edition_id: category.id,
+      nomination_id: nominationA.id
+    });
+
+    const beforeChange = await getJson<{
+      standings: Array<{ seat_number: number; points: number }>;
+    }>(`/drafts/${draft.id}/standings`);
+    expect(beforeChange.status).toBe(200);
+    const initialPoints = new Map(
+      beforeChange.json.standings.map((s) => [s.seat_number, s.points])
+    );
+    expect(initialPoints.get(1)).toBe(1);
+    expect(initialPoints.get(2)).toBe(0);
+
+    await insertCeremonyWinner(db.pool, {
+      ceremony_id: league.ceremony_id,
+      category_edition_id: category.id,
+      nomination_id: nominationB.id
+    });
+
+    const afterChange = await getJson<{
+      standings: Array<{ seat_number: number; points: number }>;
+    }>(`/drafts/${draft.id}/standings`);
+    expect(afterChange.status).toBe(200);
+    const updatedPoints = new Map(
+      afterChange.json.standings.map((s) => [s.seat_number, s.points])
+    );
+    expect(updatedPoints.get(1)).toBe(0);
+    expect(updatedPoints.get(2)).toBe(1);
   });
 });

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -16,6 +16,7 @@
 - League creation: creating a league automatically creates the initial EXTANT season for the active ceremony and adds the creator as OWNER/member in the same transaction.
 - Additional seasons: commissioners can add a new EXTANT season for the active ceremony (one per ceremony). Season lists include an `is_active_ceremony` marker; season creation is blocked if no active ceremony or an extant season already exists for that ceremony.
 - Ceremony winners: `ceremony_winner` stores the winning `nomination_id` per `category_edition` (unique). `ceremony.draft_locked_at` records when winners entry begins; it is set once and never unlocked in MVP.
+- Standings/results source of truth: draft standings pull winners from `ceremony_winner` for the draft’s ceremony (shared across drafts); the legacy `draft_result` table is not used for scoring.
 - Season membership & invites: `season_member` tracks users per season (unique per season/user, roles OWNER/CO_OWNER/MEMBER); `season_invite` supports placeholder (token-hash, single-use) and user-targeted invites with lifecycle statuses (PENDING/CLAIMED/REVOKED/DECLINED). Pending user-targeted invites are unique per (season, intended_user). Placeholder tokens store SHA-256 hex digests; no expiry in MVP.
 - User-targeted invites are commissioner-created, surface only in an authenticated inbox for the intended user, and accept/decline is only allowed while drafts for the ceremony have not started; accepting atomically adds league + season membership.
 

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -9,6 +9,6 @@
 
 ## Results ingestion + standings
 
-- Results are stored per draft via `POST /drafts/:id/results` with payload:
-  - `{ results: [{ nomination_id, won, points? }] }`
-- Standings are computed via `GET /drafts/:id/standings`, returning draft state, results, and per-seat points + picks.
+- Ceremony winners are entered centrally (admin-only) and stored in `ceremony_winner` (one winning `nomination_id` per `category_edition`).
+- Standings are derived from ceremony winners for the draft’s season/corresponding ceremony; all drafts for that ceremony see the same winners.
+- `GET /drafts/:id/standings` recomputes on demand using the season’s scoring strategy, returning draft state, per-pick results (won/lose), and per-seat points.


### PR DESCRIPTION
feat(api): results + standings derived from ceremony winners (not per-draft ad hoc)

Closes #166
