### PR TITLE
Fix prod login 500: self-heal missing app_user.is_admin

### DIFF
--- a/db/migrations/015_self_heal_app_user_is_admin.sql
+++ b/db/migrations/015_self_heal_app_user_is_admin.sql
@@ -1,0 +1,21 @@
+-- Self-heal for environments where the baseline schema was partially applied.
+--
+-- If `app_user.is_admin` is missing, auth endpoints that SELECT/RETURN `is_admin`
+-- will crash with a 500. This migration ensures the column exists.
+
+DO $$
+BEGIN
+  IF to_regclass('public.app_user') IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'app_user'
+        AND column_name = 'is_admin'
+    ) THEN
+      ALTER TABLE public.app_user
+        ADD COLUMN is_admin boolean NOT NULL DEFAULT false;
+    END IF;
+  END IF;
+END $$;
+


### PR DESCRIPTION
Prod /auth/login is returning HTTP 500 with {code: INTERNAL_ERROR, message: Unexpected error}. A common cause is the DB missing the `app_user.is_admin` column while auth queries still SELECT it.\n\nThis adds an idempotent migration that ensures `public.app_user.is_admin` exists (default false, not null).\n\nAfter merge, redeploying the API will run the migration and should restore login.