### PR TITLE
fix(web): stop needing reloads to see CMS content updates

### DIFF
--- a/apps/web/src/lib/revision.ts
+++ b/apps/web/src/lib/revision.ts
@@ -1,0 +1,31 @@
+const REVISION_KEY = "fantasyoscars_content_revision";
+
+function safeGetNumber(key: string): number {
+  try {
+    const raw = window.localStorage.getItem(key);
+    const n = raw ? Number.parseInt(raw, 10) : 0;
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function safeSetNumber(key: string, value: number) {
+  try {
+    window.localStorage.setItem(key, String(value));
+  } catch {
+    // ignore (private mode / disabled storage)
+  }
+}
+
+// Used to bust CDN/browser caches for public content endpoints (CMS, banners, etc.)
+// without forcing full page reloads.
+export function getContentRevision(): number {
+  return safeGetNumber(REVISION_KEY);
+}
+
+export function bumpContentRevision(): number {
+  const next = getContentRevision() + 1;
+  safeSetNumber(REVISION_KEY, next);
+  return next;
+}

--- a/apps/web/src/orchestration/adminContent.ts
+++ b/apps/web/src/orchestration/adminContent.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { fetchJson } from "../lib/api";
+import { bumpContentRevision } from "../lib/revision";
 import type { ApiResult } from "../lib/types";
 import {
   DYNAMIC_META,
@@ -83,6 +84,7 @@ export function useAdminStaticContentEditorOrchestration(args: {
       return;
     }
     setStatus({ ok: true, message: "Saved" });
+    bumpContentRevision();
   }, [body, key, title]);
 
   return {
@@ -176,6 +178,7 @@ export function useAdminDynamicContentLedgerOrchestration(args: {
       }
       await load();
       setStatus({ ok: true, message: "Published" });
+      bumpContentRevision();
     },
     [key, load]
   );
@@ -196,6 +199,7 @@ export function useAdminDynamicContentLedgerOrchestration(args: {
       }
       await load();
       setStatus({ ok: true, message: "Unpublished" });
+      bumpContentRevision();
     },
     [key, load]
   );
@@ -299,6 +303,7 @@ export function useAdminDynamicContentEditorOrchestration(args: {
     }
     setStatus({ ok: true, message: "Saved" });
     await load();
+    bumpContentRevision();
   }, [body, dismissible, endsAtLocal, entry, key, load, startsAtLocal, title, variant]);
 
   const publish = useCallback(async () => {
@@ -317,6 +322,7 @@ export function useAdminDynamicContentEditorOrchestration(args: {
     }
     setStatus({ ok: true, message: "Published" });
     await load();
+    bumpContentRevision();
   }, [entry, key, load]);
 
   const unpublish = useCallback(async () => {
@@ -335,6 +341,7 @@ export function useAdminDynamicContentEditorOrchestration(args: {
     }
     setStatus({ ok: true, message: "Unpublished" });
     await load();
+    bumpContentRevision();
   }, [entry, key, load]);
 
   const deleteEntry = useCallback(async () => {
@@ -356,6 +363,7 @@ export function useAdminDynamicContentEditorOrchestration(args: {
       setStatus({ ok: false, message: res.error ?? "Failed to delete" });
       return { ok: false as const, error: res.error ?? "Failed to delete" };
     }
+    bumpContentRevision();
     return { ok: true as const };
   }, [entry, key]);
 


### PR DESCRIPTION
Adds a lightweight client-side content revision used as a query-param cache buster for public /content/* GETs.

Admin CMS mutations bump the revision so navigating back to the landing page (or any static/dynamic content page) fetches fresh content even if an intermediate cache serves stale responses.

Also keeps everything local-only (revision stored in localStorage) and does not change API behavior.