### PR TITLE
Fix SPA reload routing + ceremony labels

### DIFF
--- a/apps/api/src/data/repositories/seasonRepository.ts
+++ b/apps/api/src/data/repositories/seasonRepository.ts
@@ -5,6 +5,7 @@ export type SeasonRecord = {
   league_id: number;
   ceremony_id: number;
   ceremony_name?: string | null;
+  ceremony_code?: string | null;
   status: "EXTANT" | "CANCELLED";
   scoring_strategy_name: "fixed" | "negative";
   remainder_strategy?: "UNDRAFTED" | "FULL_POOL";
@@ -28,6 +29,7 @@ export async function getExtantSeasonForLeague(
 	       s.league_id::int,
 	       s.ceremony_id::int,
          c.name AS ceremony_name,
+         c.code AS ceremony_code,
 	       s.status,
 	       s.scoring_strategy_name,
 	       s.remainder_strategy,
@@ -61,6 +63,7 @@ export async function getExtantSeasonForLeagueCeremony(
        s.league_id::int,
        s.ceremony_id::int,
        c.name AS ceremony_name,
+       c.code AS ceremony_code,
        s.status,
        s.scoring_strategy_name,
        s.remainder_strategy,
@@ -117,6 +120,7 @@ export async function getSeasonById(
 	       s.league_id::int,
 	       s.ceremony_id::int,
          c.name AS ceremony_name,
+         c.code AS ceremony_code,
 	       s.status,
 	       s.scoring_strategy_name,
 	       s.remainder_strategy,
@@ -170,6 +174,7 @@ export async function listSeasonsForLeague(
 	       s.league_id::int,
 	       s.ceremony_id::int,
          c.name AS ceremony_name,
+         c.code AS ceremony_code,
 	       s.status,
 	       s.scoring_strategy_name,
 	       s.remainder_strategy,
@@ -202,6 +207,7 @@ export async function getMostRecentSeason(
 	       s.league_id::int,
 	       s.ceremony_id::int,
          c.name AS ceremony_name,
+         c.code AS ceremony_code,
 	       s.status,
 	       s.scoring_strategy_name,
 	       s.remainder_strategy,

--- a/apps/api/src/routes/leagues.ts
+++ b/apps/api/src/routes/leagues.ts
@@ -438,6 +438,8 @@ export function createLeaguesRouter(client: DbClient, authSecret: string): Route
         const response = seasons.map((s) => ({
           id: s.id,
           ceremony_id: s.ceremony_id,
+          ceremony_name: s.ceremony_name ?? null,
+          ceremony_code: s.ceremony_code ?? null,
           status: s.status,
           scoring_strategy_name: s.scoring_strategy_name,
           remainder_strategy: s.remainder_strategy,

--- a/apps/web/public/static.json
+++ b/apps/web/public/static.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "src": "/*",
+      "dest": "/index.html"
+    }
+  ]
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -31,6 +31,7 @@ export type SeasonSummary = {
   league_id: number;
   ceremony_id: number;
   ceremony_name?: string | null;
+  ceremony_code?: string | null;
   status: string;
   created_at: string;
   ceremony_starts_at?: string | null;
@@ -72,6 +73,7 @@ export type SeasonMeta = {
   id: number;
   ceremony_id: number;
   ceremony_name?: string | null;
+  ceremony_code?: string | null;
   status: string;
   scoring_strategy_name?: string;
   is_active_ceremony?: boolean;

--- a/apps/web/src/screens/leagues/LeagueDetailScreen.tsx
+++ b/apps/web/src/screens/leagues/LeagueDetailScreen.tsx
@@ -22,14 +22,11 @@ import "../../primitives/baseline.css";
 function ceremonyLabelForSeason(season: {
   ceremony_starts_at?: string | null;
   ceremony_name?: string | null;
+  ceremony_code?: string | null;
   ceremony_id: number;
 }) {
   if (season.ceremony_name) return season.ceremony_name;
-  const iso = season.ceremony_starts_at;
-  if (iso) {
-    const d = new Date(iso);
-    if (!Number.isNaN(d.getTime())) return `Ceremony ${d.getFullYear()}`;
-  }
+  if (season.ceremony_code) return season.ceremony_code;
   return `Ceremony ${season.ceremony_id}`;
 }
 

--- a/apps/web/src/screens/seasons/SeasonScreen.tsx
+++ b/apps/web/src/screens/seasons/SeasonScreen.tsx
@@ -44,6 +44,7 @@ export function SeasonScreen(props: {
   const ceremonyId = s.leagueContext?.season?.ceremony_id ?? null;
   const ceremonyName =
     s.leagueContext?.season?.ceremony_name ??
+    s.leagueContext?.season?.ceremony_code ??
     (ceremonyId ? `Ceremony ${ceremonyId}` : `Ceremony`);
 
   const progression = useMemo(() => {


### PR DESCRIPTION
- Adds Render static site rewrite config (apps/web/public/static.json) so reloading deep links serves index.html\n- Include ceremony_name/ceremony_code in /leagues/:id/seasons payload and use ceremony_code as fallback label in season/league UIs