### PR TITLE
Privacy: hide emails in invite dropdown

### DIFF
--- a/apps/api/src/routes/seasons.ts
+++ b/apps/api/src/routes/seasons.ts
@@ -1339,11 +1339,10 @@ export function createSeasonsRouter(client: DbClient, authSecret: string): Route
         const { rows } = await query<{
           id: number;
           username: string;
-          email: string | null;
         }>(
           client,
           `
-            SELECT u.id::int, u.username, u.email
+            SELECT u.id::int, u.username
             FROM app_user u
             WHERE (
                 u.username ILIKE $1 ESCAPE '\\'

--- a/apps/web/src/orchestration/seasons.ts
+++ b/apps/web/src/orchestration/seasons.ts
@@ -261,7 +261,7 @@ export function useSeasonOrchestration(seasonId: number, userSub?: string) {
     null
   );
   const [userInviteMatches, setUserInviteMatches] = useState<
-    Array<{ id: number; username: string; email: string | null }>
+    Array<{ id: number; username: string }>
   >([]);
   const [userInviteSearching, setUserInviteSearching] = useState(false);
   const [placeholderLabel, setPlaceholderLabel] = useState("");
@@ -309,7 +309,7 @@ export function useSeasonOrchestration(seasonId: number, userSub?: string) {
       void (async () => {
         setUserInviteSearching(true);
         const res = await fetchJson<{
-          users: Array<{ id: number; username: string; email: string | null }>;
+          users: Array<{ id: number; username: string }>;
         }>(`/seasons/${seasonId}/invitees?q=${encodeURIComponent(q)}`, { method: "GET" });
         if (cancelled) return;
         setUserInviteSearching(false);

--- a/apps/web/src/screens/seasons/SeasonScreen.tsx
+++ b/apps/web/src/screens/seasons/SeasonScreen.tsx
@@ -308,8 +308,7 @@ export function SeasonScreen(props: {
                   searching={Boolean(s.userInviteSearching)}
                   options={s.userInviteMatches.map((u) => ({
                     id: u.id,
-                    username: u.username,
-                    email: u.email ?? null
+                    username: u.username
                   }))}
                   onChange={(next) => s.setUserInviteQuery(next)}
                   onPick={(id, username) => {
@@ -602,7 +601,7 @@ function InviteUserCombobox(props: {
   value: string;
   disabled: boolean;
   searching: boolean;
-  options: Array<{ id: number; username: string; email: string | null }>;
+  options: Array<{ id: number; username: string }>;
   onChange: (next: string) => void;
   onPick: (id: number, username: string) => void;
 }) {
@@ -659,14 +658,7 @@ function InviteUserCombobox(props: {
           ) : (
             options.map((o) => (
               <Combobox.Option key={o.id} value={String(o.id)}>
-                <Stack gap={0}>
-                  <Text className="baseline-textBody">{o.username}</Text>
-                  {o.email ? (
-                    <Text className="baseline-textMeta" c="dimmed" size="sm">
-                      {o.email}
-                    </Text>
-                  ) : null}
-                </Stack>
+                <Text className="baseline-textBody">{o.username}</Text>
               </Combobox.Option>
             ))
           )}


### PR DESCRIPTION
Stops returning user emails from /seasons/:id/invitees and removes email display from the season invitee combobox. Search still matches by username or email, but we no longer expose other users' emails in the UI.