### PR TITLE
Draft buckle countdown pulse + audio

### DIFF
--- a/apps/web/src/lib/draftAudio.ts
+++ b/apps/web/src/lib/draftAudio.ts
@@ -1,0 +1,97 @@
+export type DraftAudioController = {
+  ctx: AudioContext;
+};
+
+function rampGain(
+  gain: GainNode,
+  args: { at: number; attackMs: number; holdMs: number; releaseMs: number; peak: number }
+) {
+  const a = args.at;
+  const attack = args.attackMs / 1000;
+  const hold = args.holdMs / 1000;
+  const release = args.releaseMs / 1000;
+  gain.gain.cancelScheduledValues(a);
+  gain.gain.setValueAtTime(0.0001, a);
+  gain.gain.exponentialRampToValueAtTime(Math.max(0.0001, args.peak), a + attack);
+  gain.gain.setValueAtTime(Math.max(0.0001, args.peak), a + attack + hold);
+  gain.gain.exponentialRampToValueAtTime(0.0001, a + attack + hold + release);
+}
+
+function playTone(
+  ctx: AudioContext,
+  args: { hz: number; at: number; ms: number; gain: number }
+) {
+  const osc = ctx.createOscillator();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(args.hz, args.at);
+
+  const g = ctx.createGain();
+  g.gain.setValueAtTime(0.0001, args.at);
+
+  osc.connect(g);
+  g.connect(ctx.destination);
+
+  // Slight envelope to avoid clicks.
+  rampGain(g, {
+    at: args.at,
+    attackMs: 6,
+    holdMs: Math.max(10, args.ms - 14),
+    releaseMs: 8,
+    peak: Math.max(0.0001, args.gain)
+  });
+
+  osc.start(args.at);
+  osc.stop(args.at + args.ms / 1000);
+}
+
+export function createDraftAudioController(): DraftAudioController | null {
+  if (typeof window === "undefined") return null;
+  const Ctx =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: AudioContext }).webkitAudioContext;
+  if (!Ctx) return null;
+  try {
+    return { ctx: new Ctx() };
+  } catch {
+    return null;
+  }
+}
+
+export async function unlockDraftAudio(controller: DraftAudioController | null) {
+  const ctx = controller?.ctx;
+  if (!ctx) return;
+  if (ctx.state === "suspended") {
+    try {
+      await ctx.resume();
+    } catch {
+      // best-effort; if the browser blocks it we just stay silent
+    }
+  }
+}
+
+export async function closeDraftAudio(controller: DraftAudioController | null) {
+  const ctx = controller?.ctx;
+  if (!ctx) return;
+  try {
+    await ctx.close();
+  } catch {
+    // ignore
+  }
+}
+
+export function playCountdownBeep(controller: DraftAudioController | null) {
+  const ctx = controller?.ctx;
+  if (!ctx) return;
+  const t = ctx.currentTime;
+  // Slightly louder/longer to be audible on laptops without being jarring.
+  playTone(ctx, { hz: 880, at: t, ms: 90, gain: 0.075 });
+}
+
+export function playTurnStartChime(controller: DraftAudioController | null) {
+  const ctx = controller?.ctx;
+  if (!ctx) return;
+  const t = ctx.currentTime;
+  // Two-note chime: ~660Hz -> ~880Hz.
+  playTone(ctx, { hz: 660, at: t, ms: 120, gain: 0.065 });
+  playTone(ctx, { hz: 880, at: t + 0.14, ms: 160, gain: 0.075 });
+}

--- a/apps/web/src/lib/draftCountdown.ts
+++ b/apps/web/src/lib/draftCountdown.ts
@@ -1,0 +1,11 @@
+export const COUNTDOWN_WINDOW_MS = 5000;
+export const COUNTDOWN_BEEP_INTERVAL_MS = 700;
+
+export function isCountdownActive(timerRemainingMs: number | null) {
+  return (
+    typeof timerRemainingMs === "number" &&
+    Number.isFinite(timerRemainingMs) &&
+    timerRemainingMs > 0 &&
+    timerRemainingMs <= COUNTDOWN_WINDOW_MS
+  );
+}

--- a/apps/web/src/orchestration/draftPreview.ts
+++ b/apps/web/src/orchestration/draftPreview.ts
@@ -177,6 +177,7 @@ export function useDraftPreviewOrchestration(args: {
       direction: "FORWARD",
       hasTimer: true,
       clockText: "1:23",
+      timerRemainingMs: null,
       poolMode,
       setPoolMode,
       view,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -650,6 +650,35 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
   --drh-buckle-contact: rgba(0, 0, 0, 0.18);
 }
 
+/* Countdown pulse (5s window): toggled via class in sync with beeps. */
+.drh-buckle.is-countdown {
+  /* Default to gold for the countdown surface; JS toggles to pulse-red as needed. */
+  --drh-buckle-base: var(--fo-gold);
+  transition:
+    background 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease;
+}
+
+.drh-buckle.is-countdown.pulse-gold {
+  --drh-buckle-base: var(--fo-gold);
+}
+
+.drh-buckle.is-countdown.pulse-red {
+  /* Restrained red that still reads as urgency against our neutral palette. */
+  --drh-buckle-base: #b34b42;
+  --drh-buckle-contact: rgba(0, 0, 0, 0.26);
+}
+
+.drh-buckle.is-countdown.pulse-red .drh-buckleCenter,
+.drh-buckle.is-countdown.pulse-red .drh-buckleNumber {
+  color: var(--fo-ivory);
+}
+
+.drh-buckle.is-countdown.pulse-red .drh-buckleLabel {
+  color: rgba(var(--fo-ivory-rgb), 0.78);
+}
+
 .drh-buckleStack {
   display: flex;
   flex-direction: column;
@@ -917,6 +946,11 @@ body[data-mantine-color-scheme="dark"] .drh-userBadge {
     calc(var(--u) * var(--rail-auto));
 }
 
+.dr-layout > * {
+  /* Critical for scrollable children inside grid items. */
+  min-height: 0;
+}
+
 .dr-rail {
   position: relative;
   display: flex;
@@ -924,6 +958,7 @@ body[data-mantine-color-scheme="dark"] .drh-userBadge {
   justify-content: stretch;
   height: 100%;
   width: 100%;
+  min-height: 0;
   padding: 0;
   border: 0;
   background: var(--fo-surface-card-primary);
@@ -951,10 +986,12 @@ body[data-mantine-color-scheme="dark"] .dr-railToggle:focus-visible {
 
 .dr-rail.is-open {
   border: var(--fo-border-width) solid var(--fo-border);
+  z-index: 1;
 }
 
 .dr-rail.is-collapsed {
   border: var(--fo-border-width) solid var(--fo-border);
+  z-index: 2; /* keep stub icons visible when adjacent rails are open */
 }
 
 .dr-rail-ledger {
@@ -1293,6 +1330,7 @@ body[data-mantine-color-scheme="dark"] .dr-card {
   align-items: center;
   gap: 6px;
   margin: 0 0 10px 0;
+  cursor: default;
 }
 
 .dr-card-titleRow:focus-visible {


### PR DESCRIPTION
Implements last-5s countdown behavior in the draft header buckle.

- Adds Web Audio-based countdown beep (700ms) + turn-start two-note chime (gesture-gated)
- Adds buckle pulse classes (gold <-> restrained red) driven by timerRemainingMs
- Countdown + audio only run for the active drafter (my turn)
- Adds timerRemainingMs to draft orchestration (preview sets null)
- Adds 1s server-side delay for USER_AUTODRAFT picks (still immediate for TIMER_EXPIRED)

CI: `pnpm -w run ci:tests` + `pnpm -w run ci:docs` run locally.