### PR TITLE
Fix category template search errors and allow free-form icon input

### DIFF
--- a/apps/web/src/features/admin/screens/categoryTemplates/AdminCategoryTemplatesScreen.tsx
+++ b/apps/web/src/features/admin/screens/categoryTemplates/AdminCategoryTemplatesScreen.tsx
@@ -139,7 +139,6 @@ export function AdminCategoryTemplatesScreen(props: {
         onClose={o.closeEditor}
         title={o.isEditing ? "Edit template" : "New template"}
         working={o.working}
-        iconCodes={o.iconCodes}
         value={o.editorValue}
         setValue={o.setEditorValue}
         status={o.status}

--- a/apps/web/src/features/admin/ui/categoryTemplates/CategoryTemplateEditorModal.tsx
+++ b/apps/web/src/features/admin/ui/categoryTemplates/CategoryTemplateEditorModal.tsx
@@ -14,7 +14,6 @@ export function CategoryTemplateEditorModal(props: {
   opened: boolean;
   title: string;
   working: boolean;
-  iconCodes: string[];
   value: CategoryTemplateDraft | null;
   setValue: Dispatch<SetStateAction<CategoryTemplateDraft | null>>;
   status: ApiResult | null;
@@ -71,12 +70,14 @@ export function CategoryTemplateEditorModal(props: {
             { value: "PERFORMANCE", label: "Performance" }
           ]}
         />
-        <Select
+        <TextInput
           label="Icon"
-          searchable
           value={props.value?.icon ?? ""}
-          onChange={(v) => props.setValue((p) => (p ? { ...p, icon: v ?? "trophy" } : p))}
-          data={props.iconCodes.map((code) => ({ value: code, label: code }))}
+          onChange={(e) => {
+            const v = e.currentTarget.value;
+            props.setValue((p) => (p ? { ...p, icon: v } : p));
+          }}
+          placeholder="trophy"
           disabled={props.working}
         />
         <Select


### PR DESCRIPTION
## Summary
- fix admin category templates search to filter in-memory instead of issuing a request on every keystroke
- keep initial loading behavior while avoiding full error-state flips during interactive search
- change template icon field from a constrained select to a free-form text input so new icon codes can be entered
- remove now-unused icon-codes prop wiring from the templates screen

## Testing
- pnpm run ci
- pnpm run docs:check