### PR TITLE
Fix templates search and unlock people add flow

### DIFF
--- a/apps/api/src/lib/tmdb.ts
+++ b/apps/api/src/lib/tmdb.ts
@@ -44,6 +44,13 @@ type TmdbPersonDetails = {
   profile_path?: string | null;
 };
 
+type TmdbPersonSearchResult = {
+  id: number;
+  name: string;
+  known_for_department?: string | null;
+  profile_path?: string | null;
+};
+
 const TMDB_BASE_URL = "https://api.themoviedb.org/3";
 
 function requireTmdbReadToken(env: NodeJS.ProcessEnv = process.env): string {
@@ -181,6 +188,23 @@ export async function fetchTmdbPersonDetails(
   tmdbPersonId: number
 ): Promise<TmdbPersonDetails> {
   return tmdbGetJson<TmdbPersonDetails>(`/person/${tmdbPersonId}`, { language: "en-US" });
+}
+
+export async function searchTmdbPeople(
+  queryText: string
+): Promise<TmdbPersonSearchResult[]> {
+  const queryTrimmed = String(queryText ?? "").trim();
+  if (!queryTrimmed) return [];
+  const res = await tmdbGetJson<{ results?: TmdbPersonSearchResult[] }>(
+    "/search/person",
+    {
+      query: queryTrimmed,
+      language: "en-US",
+      include_adult: "false",
+      page: 1
+    }
+  );
+  return Array.isArray(res.results) ? res.results : [];
 }
 
 export function parseReleaseYear(releaseDate: string | null | undefined): number | null {

--- a/apps/api/src/routes/admin/people.ts
+++ b/apps/api/src/routes/admin/people.ts
@@ -1,9 +1,11 @@
 import type { Router } from "express";
 import type { DbClient } from "../../data/db.js";
 import { registerAdminPeopleListRoute } from "./peopleList.js";
+import { registerAdminPeopleTmdbSearchRoute } from "./peopleTmdbSearch.js";
 import { registerAdminPeopleUpdateRoute } from "./peopleUpdate.js";
 
 export function registerAdminPeopleRoutes(router: Router, client: DbClient): void {
   registerAdminPeopleListRoute({ router, client });
+  registerAdminPeopleTmdbSearchRoute({ router, client });
   registerAdminPeopleUpdateRoute({ router, client });
 }

--- a/apps/api/src/routes/admin/peopleTmdbSearch.ts
+++ b/apps/api/src/routes/admin/peopleTmdbSearch.ts
@@ -1,0 +1,78 @@
+import type express from "express";
+import type { Router } from "express";
+import type { AuthedRequest } from "../../auth/middleware.js";
+import { query, type DbClient } from "../../data/db.js";
+import {
+  buildTmdbImageUrlFromConfig,
+  getTmdbImageConfig,
+  searchTmdbPeople
+} from "../../lib/tmdb.js";
+
+export function registerAdminPeopleTmdbSearchRoute(args: {
+  router: Router;
+  client: DbClient;
+}): void {
+  const { router, client } = args;
+
+  router.get(
+    "/people/tmdb-search",
+    async (req: AuthedRequest, res: express.Response, next: express.NextFunction) => {
+      try {
+        const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+        if (!q || q.length < 2) return res.status(200).json({ results: [] });
+
+        const tmdbResults = (await searchTmdbPeople(q)).slice(0, 12);
+        const tmdbIds = tmdbResults
+          .map((r) => Number(r.id))
+          .filter((id) => Number.isInteger(id) && id > 0);
+        const linkedByTmdbId = new Map<
+          number,
+          { person_id: number; person_name: string }
+        >();
+        if (tmdbIds.length > 0) {
+          const { rows } = await query<{
+            person_id: number;
+            person_name: string;
+            tmdb_id: number;
+          }>(
+            client,
+            `SELECT id::int AS person_id, full_name AS person_name, tmdb_id::int
+             FROM person
+             WHERE tmdb_id = ANY($1::int[])
+             ORDER BY id ASC`,
+            [tmdbIds]
+          );
+          for (const row of rows) {
+            linkedByTmdbId.set(Number(row.tmdb_id), {
+              person_id: Number(row.person_id),
+              person_name: row.person_name
+            });
+          }
+        }
+
+        const cfg = await getTmdbImageConfig();
+        const results = tmdbResults.map((person) => {
+          const tmdbId = Number(person.id);
+          const linked = linkedByTmdbId.get(tmdbId) ?? null;
+          return {
+            tmdb_id: tmdbId,
+            name: person.name,
+            known_for_department: person.known_for_department ?? null,
+            profile_url: buildTmdbImageUrlFromConfig(
+              cfg,
+              "profile",
+              person.profile_path ?? null,
+              "w185"
+            ),
+            linked_person_id: linked?.person_id ?? null,
+            linked_person_name: linked?.person_name ?? null
+          };
+        });
+
+        return res.status(200).json({ results });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+}

--- a/apps/web/src/features/admin/screens/ceremonies/AdminCeremoniesNomineesScreen.tsx
+++ b/apps/web/src/features/admin/screens/ceremonies/AdminCeremoniesNomineesScreen.tsx
@@ -7,6 +7,7 @@ import { notify } from "@/notifications";
 import { StandardCard } from "@/primitives";
 import { CandidatePoolAccordion } from "@/features/admin/ui/ceremonies/nominees/CandidatePoolAccordion";
 import { CreateNominationPanel } from "@/features/admin/ui/ceremonies/nominees/CreateNominationPanel";
+import type { SelectedContributor } from "@/features/admin/ui/ceremonies/nominees/PeopleCombobox";
 import { CategoryNominationSection } from "./nominees/CategoryNominationSection";
 import { NominationEditModal } from "./nominees/NominationEditModal";
 import "@/primitives/baseline.css";
@@ -35,10 +36,10 @@ export function AdminCeremoniesNomineesScreen(props: {
     creditsLoading,
     creditsState,
     creditOptions,
-    setSelectedContributorIds,
-    pendingContributorId,
-    setPendingContributorId,
-    selectedCredits
+    selectedContributors,
+    setSelectedContributors,
+    pendingContributorInput,
+    setPendingContributorInput
   } = o;
 
   const {
@@ -62,20 +63,25 @@ export function AdminCeremoniesNomineesScreen(props: {
 
   const [candidateOpen, setCandidateOpen] = useState<string | null>(null);
 
-  const hasTmdbCredits = Boolean(
-    o.credits && (o.credits.cast?.length || o.credits.crew?.length)
-  );
   const requiresContributor = selectedCategory?.unit_kind === "PERFORMANCE";
-
-  const addPendingContributor = () => {
-    const id = Number(pendingContributorId);
-    if (!Number.isFinite(id) || id <= 0) return;
-    setSelectedContributorIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
-    setPendingContributorId("");
+  const localContributorOptions = useMemo(
+    () =>
+      creditOptions.map((c) => ({
+        key: `tmdb:${c.tmdb_id}`,
+        name: c.name,
+        tmdb_id: c.tmdb_id,
+        label: c.label
+      })),
+    [creditOptions]
+  );
+  const addSelectedContributor = (contributor: SelectedContributor) => {
+    setSelectedContributors((prev) =>
+      prev.some((c) => c.key === contributor.key) ? prev : [...prev, contributor]
+    );
+    setPendingContributorInput("");
   };
-
-  const removeSelectedContributor = (tmdbId: number) => {
-    setSelectedContributorIds((prev) => prev.filter((id) => id !== tmdbId));
+  const removeSelectedContributor = (key: string) => {
+    setSelectedContributors((prev) => prev.filter((c) => c.key !== key));
   };
 
   const candidateLoaded = useMemo(() => {
@@ -135,14 +141,13 @@ export function AdminCeremoniesNomineesScreen(props: {
         songTitle={songTitle}
         setSongTitle={setSongTitle}
         requiresContributor={Boolean(requiresContributor)}
-        hasTmdbCredits={hasTmdbCredits}
         creditsLoading={creditsLoading}
         creditsState={creditsState}
-        creditOptions={creditOptions}
-        pendingContributorId={pendingContributorId}
-        setPendingContributorId={setPendingContributorId}
-        onAddPendingContributor={addPendingContributor}
-        selectedCredits={selectedCredits}
+        localContributorOptions={localContributorOptions}
+        pendingContributorInput={pendingContributorInput}
+        setPendingContributorInput={setPendingContributorInput}
+        selectedContributors={selectedContributors}
+        onAddSelectedContributor={addSelectedContributor}
         onRemoveSelectedContributor={removeSelectedContributor}
         manualLoading={manualLoading}
         manualState={manualState}

--- a/apps/web/src/features/admin/ui/ceremonies/nominees/PeopleCombobox.tsx
+++ b/apps/web/src/features/admin/ui/ceremonies/nominees/PeopleCombobox.tsx
@@ -1,0 +1,255 @@
+import { Combobox, Group, Image, InputBase, Stack, Text, useCombobox } from "@ui";
+import { useEffect, useMemo, useState } from "react";
+import { includesNormalized } from "@fantasy-oscars/shared";
+import { fetchJson } from "@/lib/api";
+
+export type SelectedContributor = {
+  key: string;
+  name: string;
+  tmdb_id: number | null;
+};
+
+export function PeopleCombobox(props: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  localOptions: Array<{
+    key: string;
+    name: string;
+    tmdb_id: number | null;
+    label: string;
+  }>;
+  onSelectContributor: (input: SelectedContributor) => void;
+  disabled?: boolean;
+}) {
+  const { label, value, onChange, localOptions, onSelectContributor, disabled } = props;
+
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption()
+  });
+  const [mode, setMode] = useState<"local" | "tmdb">("local");
+  const [tmdbLoading, setTmdbLoading] = useState(false);
+  const [tmdbResults, setTmdbResults] = useState<
+    Array<{
+      tmdb_id: number;
+      name: string;
+      known_for_department: string | null;
+      profile_url: string | null;
+      linked_person_id: number | null;
+      linked_person_name: string | null;
+    }>
+  >([]);
+
+  useEffect(() => {
+    if (value.trim()) return;
+    setMode("local");
+    setTmdbLoading(false);
+    setTmdbResults([]);
+  }, [value]);
+
+  useEffect(() => {
+    if (mode !== "tmdb") {
+      setTmdbLoading(false);
+      setTmdbResults([]);
+      return;
+    }
+    const q = value.trim();
+    if (!q || q.length < 2) {
+      setTmdbLoading(false);
+      setTmdbResults([]);
+      return;
+    }
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setTmdbLoading(true);
+      void fetchJson<{
+        results: Array<{
+          tmdb_id: number;
+          name: string;
+          known_for_department: string | null;
+          profile_url: string | null;
+          linked_person_id: number | null;
+          linked_person_name: string | null;
+        }>;
+      }>(`/admin/people/tmdb-search?q=${encodeURIComponent(q)}`, {
+        method: "GET"
+      }).then((res) => {
+        if (cancelled) return;
+        setTmdbLoading(false);
+        if (!res.ok) {
+          setTmdbResults([]);
+          return;
+        }
+        setTmdbResults(res.data?.results ?? []);
+      });
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [mode, value]);
+
+  const filteredLocalOptions = useMemo(() => {
+    return localOptions.filter((p) => includesNormalized(p.label, value)).slice(0, 50);
+  }, [localOptions, value]);
+
+  return (
+    <Combobox
+      store={combobox}
+      withinPortal
+      position="bottom-start"
+      middlewares={{ flip: true, shift: true }}
+      onOptionSubmit={(val) => {
+        if (val.startsWith("mode:tmdb:")) {
+          setMode("tmdb");
+          combobox.openDropdown();
+          return;
+        }
+        if (val.startsWith("create-unlinked:")) {
+          const name = val.slice("create-unlinked:".length).trim();
+          if (!name) return;
+          onSelectContributor({
+            key: `unlinked:${name.toLowerCase()}`,
+            name,
+            tmdb_id: null
+          });
+          onChange("");
+          setMode("local");
+          combobox.closeDropdown();
+          return;
+        }
+        if (val.startsWith("local:")) {
+          const key = val.slice("local:".length);
+          const picked = localOptions.find((p) => p.key === key);
+          if (!picked) return;
+          onSelectContributor({
+            key: picked.key,
+            name: picked.name,
+            tmdb_id: picked.tmdb_id ?? null
+          });
+          onChange("");
+          combobox.closeDropdown();
+          return;
+        }
+        if (val.startsWith("tmdb:")) {
+          const tmdbId = Number(val.slice("tmdb:".length));
+          const picked = tmdbResults.find((r) => r.tmdb_id === tmdbId);
+          if (!picked) return;
+          if (picked.linked_person_id && picked.linked_person_name) {
+            onSelectContributor({
+              key: `person:${picked.linked_person_id}`,
+              name: picked.linked_person_name,
+              tmdb_id: picked.tmdb_id
+            });
+          } else {
+            onSelectContributor({
+              key: `tmdb:${picked.tmdb_id}`,
+              name: picked.name,
+              tmdb_id: picked.tmdb_id
+            });
+          }
+          onChange("");
+          setMode("local");
+          combobox.closeDropdown();
+          return;
+        }
+      }}
+    >
+      <Combobox.Target>
+        <InputBase
+          label={label}
+          component="input"
+          value={value}
+          disabled={disabled}
+          onChange={(e) => {
+            onChange(e.currentTarget.value);
+            combobox.openDropdown();
+          }}
+          onFocus={() => combobox.openDropdown()}
+          placeholder="Search people…"
+        />
+      </Combobox.Target>
+
+      <Combobox.Dropdown>
+        {mode === "local" ? (
+          <Combobox.Options>
+            {filteredLocalOptions.length === 0 ? (
+              <Combobox.Empty>
+                <Text size="sm" className="muted">
+                  No matching people
+                </Text>
+              </Combobox.Empty>
+            ) : (
+              filteredLocalOptions.map((o) => (
+                <Combobox.Option key={o.key} value={`local:${o.key}`}>
+                  <Text size="sm">{o.label}</Text>
+                </Combobox.Option>
+              ))
+            )}
+          </Combobox.Options>
+        ) : (
+          <Combobox.Options className="fo-filmComboboxResults">
+            {tmdbLoading ? (
+              <Combobox.Empty>
+                <Text size="sm" className="muted">
+                  Searching TMDB...
+                </Text>
+              </Combobox.Empty>
+            ) : tmdbResults.length === 0 ? (
+              <Combobox.Empty>
+                <Text size="sm" className="muted">
+                  No TMDB matches
+                </Text>
+              </Combobox.Empty>
+            ) : (
+              tmdbResults.map((r) => (
+                <Combobox.Option key={`tmdb-${r.tmdb_id}`} value={`tmdb:${r.tmdb_id}`}>
+                  <Group gap="sm" align="flex-start" wrap="nowrap">
+                    <Image
+                      src={r.profile_url}
+                      alt=""
+                      className="fo-filmSearchPoster"
+                      radius="sm"
+                    />
+                    <Stack gap="var(--fo-space-4)" className="fo-flex1Minw0">
+                      <Text size="sm" fw="var(--fo-font-weight-semibold)" lineClamp={1}>
+                        {r.name}
+                      </Text>
+                      <Text size="xs" className="muted">
+                        {r.known_for_department ?? "Department unknown"}
+                      </Text>
+                      {r.linked_person_id ? (
+                        <Text size="xs" c="dimmed" lineClamp={1}>
+                          Already linked to:{" "}
+                          {r.linked_person_name ?? `Person #${r.linked_person_id}`}
+                        </Text>
+                      ) : null}
+                    </Stack>
+                  </Group>
+                </Combobox.Option>
+              ))
+            )}
+          </Combobox.Options>
+        )}
+        {mode === "local" && value.trim() ? (
+          <Combobox.Options className="fo-filmComboboxEscape">
+            <Combobox.Option value={`mode:tmdb:${value.trim()}`}>
+              <Text size="sm" fw="var(--fo-font-weight-bold)">
+                Create person: {value.trim()}
+              </Text>
+            </Combobox.Option>
+          </Combobox.Options>
+        ) : null}
+        {mode === "tmdb" && value.trim() ? (
+          <Combobox.Options className="fo-filmComboboxEscape">
+            <Combobox.Option value={`create-unlinked:${value.trim()}`}>
+              <Text size="sm" fw="var(--fo-font-weight-bold)">
+                Create unlinked person: {value.trim()}
+              </Text>
+            </Combobox.Option>
+          </Combobox.Options>
+        ) : null}
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+}


### PR DESCRIPTION
## Summary\n- fix category template search by filtering in-memory against the full loaded set\n- add admin people TMDB search endpoint ()\n- add a film-style people combobox flow for nomination creation:\n  - local existing entities (film-scoped credit options)\n  - create person -> TMDB search mode\n  - create unlinked person escape hatch\n- keep local people options rendered with simple dropdown styling\n\n## Verification\n- pnpm run ci:tests