### PR TITLE
Add contributor display overrides and duplicate contributor support

### DIFF
--- a/apps/api/src/data/repositories/nominationRepository.ts
+++ b/apps/api/src/data/repositories/nominationRepository.ts
@@ -27,6 +27,9 @@ export type NominationWithDisplay = {
     profile_url?: string | null;
     profile_path?: string | null;
     role_label: string | null;
+    display_name_override?: string | null;
+    display_role_override?: string | null;
+    avatar_person_id_override?: number | null;
     sort_order: number;
   }>;
   status?: "ACTIVE" | "REVOKED" | "REPLACED";
@@ -62,20 +65,23 @@ export async function listNominationsForCeremony(
        COALESCE(f.poster_url, sf.poster_url, pf.poster_url) AS film_poster_url,
        COALESCE(f.release_year, sf.release_year, pf.release_year) AS film_year,
        s.title AS song_title,
-       primary_person.full_name AS performer_name,
+       primary_person.display_name AS performer_name,
        primary_person.profile_url AS performer_profile_url,
        primary_person.profile_path AS performer_profile_path,
-       primary_person.role_label AS performer_character,
+       primary_person.display_role AS performer_character,
        COALESCE(
          json_agg(
            json_build_object(
              'nomination_contributor_id', nc.id::int,
              'person_id', p2.id::int,
-             'full_name', p2.full_name,
+             'full_name', COALESCE(nc.display_name_override, p2.full_name),
              'tmdb_id', p2.tmdb_id::int,
-             'profile_url', p2.profile_url,
-             'profile_path', p2.profile_path,
-             'role_label', nc.role_label,
+             'profile_url', p2_avatar.profile_url,
+             'profile_path', p2_avatar.profile_path,
+             'role_label', COALESCE(nc.display_role_override, nc.role_label),
+             'display_name_override', nc.display_name_override,
+             'display_role_override', nc.display_role_override,
+             'avatar_person_id_override', nc.avatar_person_id_override::int,
              'sort_order', nc.sort_order::int
            )
            ORDER BY nc.sort_order ASC, nc.id ASC
@@ -93,15 +99,23 @@ export async function listNominationsForCeremony(
      LEFT JOIN film pf0 ON pf0.id = perf.film_id
      LEFT JOIN film pf ON pf.id = COALESCE(pf0.consolidated_into_film_id, pf0.id)
      LEFT JOIN LATERAL (
-       SELECT p.full_name, p.profile_url, p.profile_path, nc.role_label
+       SELECT
+         COALESCE(nc.display_name_override, p.full_name) AS display_name,
+         p_avatar.profile_url,
+         p_avatar.profile_path,
+         COALESCE(nc.display_role_override, nc.role_label) AS display_role
        FROM nomination_contributor nc
        JOIN person p ON p.id = nc.person_id
+       LEFT JOIN person p_avatar
+         ON p_avatar.id = COALESCE(nc.avatar_person_id_override, nc.person_id)
        WHERE nc.nomination_id = n.id
        ORDER BY nc.sort_order ASC, nc.id ASC
        LIMIT 1
      ) primary_person ON TRUE
      LEFT JOIN nomination_contributor nc ON nc.nomination_id = n.id
      LEFT JOIN person p2 ON p2.id = nc.person_id
+     LEFT JOIN person p2_avatar
+       ON p2_avatar.id = COALESCE(nc.avatar_person_id_override, nc.person_id)
      WHERE ce.ceremony_id = $1
      GROUP BY
        n.id,
@@ -135,10 +149,10 @@ export async function listNominationsForCeremony(
         pf.poster_url,
        pf.release_year,
         s.title,
-        primary_person.full_name,
+        primary_person.display_name,
         primary_person.profile_url,
         primary_person.profile_path,
-        primary_person.role_label
+        primary_person.display_role
      ORDER BY n.category_edition_id, n.sort_order ASC, n.id ASC`,
     [ceremonyId]
   );

--- a/apps/api/src/routes/admin/nominationContributors.ts
+++ b/apps/api/src/routes/admin/nominationContributors.ts
@@ -2,11 +2,13 @@ import type { Router } from "express";
 import type { DbClient } from "../../data/db.js";
 import { registerAdminNominationContributorsAddRoute } from "./nominationContributorsAdd.js";
 import { registerAdminNominationContributorsDeleteRoute } from "./nominationContributorsDelete.js";
+import { registerAdminNominationContributorsUpdateRoute } from "./nominationContributorsUpdate.js";
 
 export function registerAdminNominationContributorRoutes(
   router: Router,
   client: DbClient
 ): void {
   registerAdminNominationContributorsAddRoute({ router, client });
+  registerAdminNominationContributorsUpdateRoute({ router, client });
   registerAdminNominationContributorsDeleteRoute({ router, client });
 }

--- a/apps/api/src/routes/admin/nominationContributorsUpdate.ts
+++ b/apps/api/src/routes/admin/nominationContributorsUpdate.ts
@@ -1,0 +1,139 @@
+import express from "express";
+import type { Router } from "express";
+import type { Pool } from "pg";
+import { AuthedRequest } from "../../auth/middleware.js";
+import { type DbClient, query, runInTransaction } from "../../data/db.js";
+import { insertAdminAudit } from "../../data/repositories/adminAuditRepository.js";
+import { hasDraftsStartedForCeremony } from "../../data/repositories/draftRepository.js";
+import { AppError } from "../../errors.js";
+
+export function registerAdminNominationContributorsUpdateRoute({
+  router,
+  client
+}: {
+  router: Router;
+  client: DbClient;
+}): void {
+  router.patch(
+    "/nominations/:id/contributors/:contributorId",
+    async (req: AuthedRequest, res: express.Response, next: express.NextFunction) => {
+      try {
+        const nominationId = Number(req.params.id);
+        const contributorId = Number(req.params.contributorId);
+        if (!Number.isInteger(nominationId) || nominationId <= 0) {
+          throw new AppError("VALIDATION_FAILED", 400, "Invalid nomination id");
+        }
+        if (!Number.isInteger(contributorId) || contributorId <= 0) {
+          throw new AppError("VALIDATION_FAILED", 400, "Invalid contributor id");
+        }
+
+        const displayNameRaw = (
+          req.body as { display_name_override?: unknown } | undefined
+        )?.display_name_override;
+        const displayRoleRaw = (
+          req.body as { display_role_override?: unknown } | undefined
+        )?.display_role_override;
+        const avatarPersonIdRaw = (
+          req.body as { avatar_person_id_override?: unknown } | undefined
+        )?.avatar_person_id_override;
+
+        const displayName =
+          typeof displayNameRaw === "string" ? displayNameRaw.trim() : "";
+        const displayRole =
+          typeof displayRoleRaw === "string" ? displayRoleRaw.trim() : "";
+        const avatarPersonId =
+          avatarPersonIdRaw === null || avatarPersonIdRaw === undefined
+            ? null
+            : typeof avatarPersonIdRaw === "number"
+              ? avatarPersonIdRaw
+              : typeof avatarPersonIdRaw === "string" && avatarPersonIdRaw.trim()
+                ? Number(avatarPersonIdRaw)
+                : NaN;
+
+        if (
+          avatarPersonId !== null &&
+          (!Number.isInteger(avatarPersonId) || avatarPersonId <= 0)
+        ) {
+          throw new AppError(
+            "VALIDATION_FAILED",
+            400,
+            "avatar_person_id_override must be a positive integer or null",
+            { fields: ["avatar_person_id_override"] }
+          );
+        }
+
+        await runInTransaction(client as Pool, async (tx) => {
+          const { rows: metaRows } = await query<{ ceremony_id: number; status: string }>(
+            tx,
+            `SELECT ce.ceremony_id::int AS ceremony_id, c.status
+             FROM nomination n
+             JOIN category_edition ce ON ce.id = n.category_edition_id
+             JOIN ceremony c ON c.id = ce.ceremony_id
+             WHERE n.id = $1`,
+            [nominationId]
+          );
+          const meta = metaRows[0];
+          if (!meta) throw new AppError("NOT_FOUND", 404, "Nomination not found");
+          if (meta.status !== "DRAFT") {
+            throw new AppError(
+              "CEREMONY_NOT_DRAFT",
+              409,
+              "Nominations can only be edited while the ceremony is in draft"
+            );
+          }
+          const draftsStarted = await hasDraftsStartedForCeremony(tx, meta.ceremony_id);
+          if (draftsStarted) {
+            throw new AppError(
+              "DRAFTS_LOCKED",
+              409,
+              "Nominee structural changes are locked after drafts start"
+            );
+          }
+
+          if (avatarPersonId !== null) {
+            const { rows: peopleRows } = await query<{ id: number }>(
+              tx,
+              `SELECT id::int FROM person WHERE id = $1`,
+              [Number(avatarPersonId)]
+            );
+            if (!peopleRows[0]?.id) {
+              throw new AppError("NOT_FOUND", 404, "Avatar source person not found");
+            }
+          }
+
+          const { rowCount } = await query(
+            tx,
+            `UPDATE nomination_contributor
+             SET display_name_override = $3,
+                 display_role_override = $4,
+                 avatar_person_id_override = $5
+             WHERE id = $1
+               AND nomination_id = $2`,
+            [
+              contributorId,
+              nominationId,
+              displayName || null,
+              displayRole || null,
+              avatarPersonId
+            ]
+          );
+          if (!rowCount) throw new AppError("NOT_FOUND", 404, "Contributor not found");
+        });
+
+        if (req.auth?.sub) {
+          await insertAdminAudit(client as Pool, {
+            actor_user_id: Number(req.auth.sub),
+            action: "update_nomination_contributor_display",
+            target_type: "nomination",
+            target_id: nominationId,
+            meta: { nomination_contributor_id: contributorId }
+          });
+        }
+
+        return res.status(200).json({ ok: true });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+}

--- a/apps/web/src/features/admin/screens/ceremonies/AdminCeremoniesNomineesScreen.tsx
+++ b/apps/web/src/features/admin/screens/ceremonies/AdminCeremoniesNomineesScreen.tsx
@@ -1,6 +1,6 @@
 import { Box, Group, Stack, Text } from "@ui";
 import { PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { AdminCeremonyNomineesOrchestration } from "@/orchestration/adminCeremoniesNominees";
 import { FormStatus } from "@/shared/forms";
 import { notify } from "@/notifications";
@@ -54,7 +54,8 @@ export function AdminCeremoniesNomineesScreen(props: {
     linkFilmTmdb,
     linkPersonTmdb,
     addNominationContributor,
-    removeNominationContributor
+    removeNominationContributor,
+    updateNominationContributorDisplay
   } = o.actions;
 
   useEffect(() => {
@@ -74,10 +75,18 @@ export function AdminCeremoniesNomineesScreen(props: {
       })),
     [creditOptions]
   );
+  const contributorInstanceIdRef = useRef(1);
   const addSelectedContributor = (contributor: SelectedContributor) => {
-    setSelectedContributors((prev) =>
-      prev.some((c) => c.key === contributor.key) ? prev : [...prev, contributor]
-    );
+    const instanceId = contributorInstanceIdRef.current;
+    contributorInstanceIdRef.current += 1;
+    setSelectedContributors((prev) => [
+      ...prev,
+      {
+        ...contributor,
+        // Keep source identity (name/tmdb) but make each attachment distinct.
+        key: `${contributor.key}#${instanceId}`
+      }
+    ]);
     setPendingContributorInput("");
   };
   const removeSelectedContributor = (key: string) => {
@@ -242,6 +251,28 @@ export function AdminCeremoniesNomineesScreen(props: {
                 durability: "ephemeral",
                 requires_decision: false,
                 message: "Contributor removed"
+              });
+            }
+          }}
+          onUpdateContributorDisplay={async (
+            nominationId,
+            nominationContributorId,
+            input
+          ) => {
+            const ok = await updateNominationContributorDisplay(
+              nominationId,
+              nominationContributorId,
+              input
+            );
+            if (ok) {
+              notify({
+                id: "admin.nominees.contributor.display.update.success",
+                severity: "success",
+                trigger_type: "user_action",
+                scope: "local",
+                durability: "ephemeral",
+                requires_decision: false,
+                message: "Contributor display updated"
               });
             }
           }}

--- a/apps/web/src/features/admin/screens/ceremonies/nominees/NominationEditModal.tsx
+++ b/apps/web/src/features/admin/screens/ceremonies/nominees/NominationEditModal.tsx
@@ -16,6 +16,9 @@ export function NominationEditModal(props: {
       full_name: string;
       tmdb_id?: number | null;
       role_label: string | null;
+      display_name_override?: string | null;
+      display_role_override?: string | null;
+      avatar_person_id_override?: number | null;
       sort_order: number;
     }>;
   };
@@ -63,6 +66,15 @@ export function NominationEditModal(props: {
     nominationId: number,
     nominationContributorId: number
   ) => Promise<void>;
+  onUpdateContributorDisplay: (
+    nominationId: number,
+    nominationContributorId: number,
+    input: {
+      display_name_override?: string | null;
+      display_role_override?: string | null;
+      avatar_person_id_override?: number | null;
+    }
+  ) => Promise<void>;
   getFilmCredits: (filmId: number) => Promise<unknown | null>;
 }) {
   const {
@@ -76,6 +88,7 @@ export function NominationEditModal(props: {
     onLinkPerson,
     onAddContributor,
     onRemoveContributor,
+    onUpdateContributorDisplay,
     getFilmCredits
   } = props;
 
@@ -144,6 +157,7 @@ export function NominationEditModal(props: {
           onLinkPerson={onLinkPerson}
           onAddContributor={onAddContributor}
           onRemoveContributor={onRemoveContributor}
+          onUpdateContributorDisplay={onUpdateContributorDisplay}
         />
       </Stack>
     </Modal>

--- a/apps/web/src/features/admin/screens/ceremonies/nominees/NominationEditPeopleSection.tsx
+++ b/apps/web/src/features/admin/screens/ceremonies/nominees/NominationEditPeopleSection.tsx
@@ -14,6 +14,9 @@ type NominationContributorRow = {
   full_name: string;
   tmdb_id?: number | null;
   role_label: string | null;
+  display_name_override?: string | null;
+  display_role_override?: string | null;
+  avatar_person_id_override?: number | null;
   sort_order: number;
 };
 
@@ -47,6 +50,15 @@ export function NominationEditPeopleSection(props: {
     nominationId: number,
     nominationContributorId: number
   ) => Promise<void>;
+  onUpdateContributorDisplay: (
+    nominationId: number,
+    nominationContributorId: number,
+    input: {
+      display_name_override?: string | null;
+      display_role_override?: string | null;
+      avatar_person_id_override?: number | null;
+    }
+  ) => Promise<void>;
 }) {
   const {
     nominationId,
@@ -57,16 +69,30 @@ export function NominationEditPeopleSection(props: {
     filmCredits,
     onLinkPerson,
     onAddContributor,
-    onRemoveContributor
+    onRemoveContributor,
+    onUpdateContributorDisplay
   } = props;
 
   const [personLinkOpenId, setPersonLinkOpenId] = useState<number | null>(null);
   const [personTmdbId, setPersonTmdbId] = useState("");
   const [pendingContributorInput, setPendingContributorInput] = useState("");
+  const [displayEditorOpenId, setDisplayEditorOpenId] = useState<number | null>(null);
+  const [displayNameOverrideInput, setDisplayNameOverrideInput] = useState("");
+  const [displayRoleOverrideInput, setDisplayRoleOverrideInput] = useState("");
+  const [avatarPersonIdOverrideInput, setAvatarPersonIdOverrideInput] = useState("");
 
   const contributorRows = useMemo(() => {
     return contributors.slice().sort((a, b) => a.sort_order - b.sort_order);
   }, [contributors]);
+  const activeDisplayContributor = useMemo(
+    () =>
+      displayEditorOpenId
+        ? (contributorRows.find(
+            (c) => c.nomination_contributor_id === displayEditorOpenId
+          ) ?? null)
+        : null,
+    [contributorRows, displayEditorOpenId]
+  );
 
   const creditByPersonId = useMemo(() => {
     const map = new Map<
@@ -279,11 +305,106 @@ export function NominationEditPeopleSection(props: {
                     {String.fromCharCode(0xe872)}
                   </Text>
                 </ActionIcon>
+                <ActionIcon
+                  variant="subtle"
+                  aria-label="Contributor display settings"
+                  onClick={() => {
+                    const cid = c.nomination_contributor_id;
+                    if (!cid) return;
+                    setDisplayEditorOpenId((prev) => (prev === cid ? null : cid));
+                    setDisplayNameOverrideInput(c.display_name_override ?? "");
+                    setDisplayRoleOverrideInput(c.display_role_override ?? "");
+                    setAvatarPersonIdOverrideInput(
+                      c.avatar_person_id_override
+                        ? String(c.avatar_person_id_override)
+                        : ""
+                    );
+                  }}
+                >
+                  <Text component="span" className="gicon" aria-hidden="true">
+                    settings
+                  </Text>
+                </ActionIcon>
               </Group>
             </Group>
           ))}
         </Stack>
       )}
+
+      {displayEditorOpenId ? (
+        <Group mt="xs" align="flex-end" wrap="wrap">
+          <TextInput
+            label="Display name override"
+            value={displayNameOverrideInput}
+            onChange={(e) => setDisplayNameOverrideInput(e.currentTarget.value)}
+            placeholder={activeDisplayContributor?.full_name ?? "Tom Hulce"}
+          />
+          <TextInput
+            label="Display role override"
+            value={displayRoleOverrideInput}
+            onChange={(e) => setDisplayRoleOverrideInput(e.currentTarget.value)}
+            placeholder={
+              activeDisplayContributor?.role_label ?? "as Wolfgang Amadeus Mozart"
+            }
+          />
+          <TextInput
+            label="Photo source person id"
+            value={avatarPersonIdOverrideInput}
+            onChange={(e) => setAvatarPersonIdOverrideInput(e.currentTarget.value)}
+            placeholder={
+              activeDisplayContributor
+                ? `Default: ${activeDisplayContributor.person_id}`
+                : "Default: contributor person id"
+            }
+          />
+          <Button
+            type="button"
+            onClick={() => {
+              const overrideIdRaw = avatarPersonIdOverrideInput.trim();
+              const avatarPersonId = overrideIdRaw === "" ? null : Number(overrideIdRaw);
+              if (
+                avatarPersonId !== null &&
+                (!Number.isInteger(avatarPersonId) || avatarPersonId <= 0)
+              ) {
+                notify({
+                  id: "admin.nominees.contributor.display.validation.error",
+                  severity: "error",
+                  trigger_type: "user_action",
+                  scope: "local",
+                  durability: "ephemeral",
+                  requires_decision: false,
+                  title: "Invalid photo source",
+                  message: "Photo source person id must be a positive integer."
+                });
+                return;
+              }
+              void onUpdateContributorDisplay(nominationId, displayEditorOpenId, {
+                display_name_override: displayNameOverrideInput.trim() || null,
+                display_role_override: displayRoleOverrideInput.trim() || null,
+                avatar_person_id_override: avatarPersonId
+              });
+              setDisplayEditorOpenId(null);
+              setDisplayNameOverrideInput("");
+              setDisplayRoleOverrideInput("");
+              setAvatarPersonIdOverrideInput("");
+            }}
+          >
+            Save display settings
+          </Button>
+          <Button
+            type="button"
+            variant="subtle"
+            onClick={() => {
+              setDisplayEditorOpenId(null);
+              setDisplayNameOverrideInput("");
+              setDisplayRoleOverrideInput("");
+              setAvatarPersonIdOverrideInput("");
+            }}
+          >
+            Cancel
+          </Button>
+        </Group>
+      ) : null}
 
       {personLinkOpenId ? (
         <Group mt="xs" align="flex-end" wrap="wrap">

--- a/apps/web/src/features/draft/components/NomineeTooltipCard.tsx
+++ b/apps/web/src/features/draft/components/NomineeTooltipCard.tsx
@@ -171,7 +171,7 @@ export function NomineeTooltipCard(props: {
         {unitKind === "PERFORMANCE" && performanceContributors.length > 1 ? (
           <Box className="fo-tip-performanceList">
             {performanceContributors.map((c, idx) => {
-              const mediaSrc = c.profileUrl ?? (idx === 0 ? resolvedFilmPosterUrl : null);
+              const mediaSrc = c.profileUrl ?? resolvedFilmPosterUrl;
               return (
                 <Box key={`${c.fullName}-${idx}`} className="fo-tip-performanceCard">
                   <Box className="fo-tip-poster" aria-hidden="true">

--- a/apps/web/src/orchestration/admin/ceremonyNominees/actions.ts
+++ b/apps/web/src/orchestration/admin/ceremonyNominees/actions.ts
@@ -39,6 +39,25 @@ export async function deleteNominationContributor(
   );
 }
 
+export async function patchNominationContributorDisplay(
+  nominationId: number,
+  nominationContributorId: number,
+  input: {
+    display_name_override?: string | null;
+    display_role_override?: string | null;
+    avatar_person_id_override?: number | null;
+  }
+) {
+  return fetchJson(
+    `/admin/nominations/${nominationId}/contributors/${nominationContributorId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input)
+    }
+  );
+}
+
 export async function getFilmCreditsRaw(filmId: number) {
   return fetchJson<{ credits: unknown | null }>(`/admin/films/${filmId}/credits`, {
     method: "GET"

--- a/apps/web/src/orchestration/admin/ceremonyNominees/orchestration.ts
+++ b/apps/web/src/orchestration/admin/ceremonyNominees/orchestration.ts
@@ -19,6 +19,7 @@ import type {
 import {
   deleteNominationContributor as deleteNominationContributorReq,
   getFilmCreditsRaw,
+  patchNominationContributorDisplay as patchNominationContributorDisplayReq,
   patchFilmTmdbId,
   patchPersonTmdbId,
   postNominationContributor as postNominationContributorReq
@@ -944,6 +945,38 @@ export function useAdminCeremonyNomineesOrchestration(args: {
     [loadNominations]
   );
 
+  const updateNominationContributorDisplay = useCallback(
+    async (
+      nominationId: number,
+      nominationContributorId: number,
+      input: {
+        display_name_override?: string | null;
+        display_role_override?: string | null;
+        avatar_person_id_override?: number | null;
+      }
+    ) => {
+      setManualLoading(true);
+      setManualState(null);
+      const res = await patchNominationContributorDisplayReq(
+        nominationId,
+        nominationContributorId,
+        input
+      );
+      setManualLoading(false);
+      if (!res.ok) {
+        setManualState({
+          ok: false,
+          message: res.error ?? "Failed to update contributor display settings"
+        });
+        return false;
+      }
+      setManualState({ ok: true, message: "Contributor display updated" });
+      await loadNominations();
+      return true;
+    },
+    [loadNominations]
+  );
+
   const getFilmCredits = useCallback(async (filmId: number) => {
     if (!Number.isFinite(filmId) || filmId <= 0) return null;
     const res = await getFilmCreditsRaw(filmId);
@@ -1026,7 +1059,8 @@ export function useAdminCeremonyNomineesOrchestration(args: {
       linkFilmTmdb,
       linkPersonTmdb,
       addNominationContributor,
-      removeNominationContributor
+      removeNominationContributor,
+      updateNominationContributorDisplay
     }
   };
 }

--- a/apps/web/src/orchestration/admin/ceremonyNominees/types.ts
+++ b/apps/web/src/orchestration/admin/ceremonyNominees/types.ts
@@ -20,6 +20,9 @@ export type NominationContributorRow = {
   full_name: string;
   tmdb_id?: number | null;
   role_label: string | null;
+  display_name_override?: string | null;
+  display_role_override?: string | null;
+  avatar_person_id_override?: number | null;
   sort_order: number;
 };
 

--- a/database/migrations/017_nomination_contributor_display_overrides.sql
+++ b/database/migrations/017_nomination_contributor_display_overrides.sql
@@ -1,0 +1,24 @@
+-- Nomination contributor display overrides for gimmick/entity styling:
+-- - display_name_override: custom label shown in cards/pills
+-- - display_role_override: custom "as ..." text
+-- - avatar_person_id_override: source person used for profile image rendering
+
+ALTER TABLE public.nomination_contributor
+  ADD COLUMN IF NOT EXISTS display_name_override text,
+  ADD COLUMN IF NOT EXISTS display_role_override text,
+  ADD COLUMN IF NOT EXISTS avatar_person_id_override bigint;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'nomination_contributor_avatar_person_id_override_fkey'
+  ) THEN
+    ALTER TABLE public.nomination_contributor
+      ADD CONSTRAINT nomination_contributor_avatar_person_id_override_fkey
+      FOREIGN KEY (avatar_person_id_override)
+      REFERENCES public.person(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary\n- add nomination contributor display override support (name, role, avatar source) with DB migration and API patch route\n- add admin UI controls (third settings icon) to edit per-contributor display overrides\n- allow attaching the same person multiple times to a nomination\n- use film poster fallback in draft tooltip rows when contributor images are missing\n- update override input placeholders to show typical/default values for the selected contributor\n\n## Validation\n- pnpm run ci:tests