### PR TITLE
fix: update delete account confirm phrase to Alan Smithee

### DIFF
--- a/apps/web/src/features/account/ui/DeleteAccountModal.tsx
+++ b/apps/web/src/features/account/ui/DeleteAccountModal.tsx
@@ -14,7 +14,7 @@ export function DeleteAccountModal(props: {
       title="Delete your account?"
       summary="This permanently removes your account. Any completed draft history will be preserved anonymously — your picks stay on the record, but your name won't be attached to them. Like a winner who asked not to be named."
       consequences={[]}
-      confirmPhrase="and the winner is"
+      confirmPhrase="I am Alan Smithee"
       confirmLabel="Delete my account"
       loading={props.working}
       error={props.error}


### PR DESCRIPTION
## Summary
- Changes the confirmation phrase for account deletion from `"and the winner is"` to `"I am Alan Smithee"` — a nod to the pseudonym used to disown a film, which ties directly into the modal's existing copy about history being preserved anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)