### PR TITLE
feat: add sound/cursor spy toggles, disable cursor spy on mobile, fix tooltip bug

### DIFF
--- a/apps/web/src/app/pages/DraftRoomPage.tsx
+++ b/apps/web/src/app/pages/DraftRoomPage.tsx
@@ -2,10 +2,17 @@ import { useParams } from "react-router-dom";
 import { useAuthContext } from "@/auth/context";
 import { useDraftRoomOrchestration } from "@/orchestration/draft";
 import { DraftRoomScreen } from "@/features/draft/screens/DraftRoomScreen";
+import { useMediaQuery } from "@ui/hooks";
+import { FO_BP_MOBILE_MAX_PX } from "@/tokens/breakpoints";
 
 export function DraftRoomPage() {
   const { id } = useParams();
   const { user } = useAuthContext();
-  const o = useDraftRoomOrchestration({ initialDraftId: id, disabled: !user });
+  const isMobile = useMediaQuery(`(max-width: ${FO_BP_MOBILE_MAX_PX}px)`);
+  const o = useDraftRoomOrchestration({
+    initialDraftId: id,
+    disabled: !user,
+    disableCursorSpy: isMobile
+  });
   return <DraftRoomScreen o={o} />;
 }

--- a/apps/web/src/features/draft/screens/DraftBoardHeader.tsx
+++ b/apps/web/src/features/draft/screens/DraftBoardHeader.tsx
@@ -213,7 +213,9 @@ export function DraftBoardHeader(props: {
   }, [props.audioController]);
 
   useEffect(() => {
-    canBeepRef.current = Boolean(props.soundEnabled && props.audioUnlocked && props.isMyTurn);
+    canBeepRef.current = Boolean(
+      props.soundEnabled && props.audioUnlocked && props.isMyTurn
+    );
   }, [props.audioUnlocked, props.isMyTurn, props.soundEnabled]);
 
   useEffect(() => {

--- a/apps/web/src/features/draft/screens/DraftBoardHeader.tsx
+++ b/apps/web/src/features/draft/screens/DraftBoardHeader.tsx
@@ -50,7 +50,12 @@ export function DraftBoardHeader(props: {
   onResumeDraft: () => void;
   audioController: ReturnType<typeof createDraftAudioController>;
   audioUnlocked: boolean;
+  soundEnabled: boolean;
+  onToggleSound: () => void;
   isMyTurn: boolean;
+  showCursorSpyToggle: boolean;
+  cursorSpyUserEnabled: boolean;
+  onToggleCursorSpy: () => void;
   userLabel: string;
   userAvatarKey: string | null;
   onParticipantHoverSeat: (seatNumber: number | null) => void;
@@ -208,8 +213,8 @@ export function DraftBoardHeader(props: {
   }, [props.audioController]);
 
   useEffect(() => {
-    canBeepRef.current = Boolean(props.audioUnlocked && props.isMyTurn);
-  }, [props.audioUnlocked, props.isMyTurn]);
+    canBeepRef.current = Boolean(props.soundEnabled && props.audioUnlocked && props.isMyTurn);
+  }, [props.audioUnlocked, props.isMyTurn, props.soundEnabled]);
 
   useEffect(() => {
     if (!countdownActive) {
@@ -380,6 +385,11 @@ export function DraftBoardHeader(props: {
               onStartDraft={props.onStartDraft}
               onPauseDraft={props.onPauseDraft}
               onResumeDraft={props.onResumeDraft}
+              soundEnabled={props.soundEnabled}
+              onToggleSound={props.onToggleSound}
+              showCursorSpyToggle={props.showCursorSpyToggle}
+              cursorSpyUserEnabled={props.cursorSpyUserEnabled}
+              onToggleCursorSpy={props.onToggleCursorSpy}
               userLabel={props.userLabel}
               userAvatarKey={props.userAvatarKey}
             />
@@ -483,6 +493,7 @@ export function DraftBoardHeader(props: {
           showDraftedVisible={props.showDraftedVisible}
           showDrafted={props.showDrafted}
           themeIcon={props.themeIcon}
+          showCursorSpyToggle={props.showCursorSpyToggle}
           userLabel={props.userLabel}
           userAvatarKey={props.userAvatarKey}
         />

--- a/apps/web/src/features/draft/screens/DraftRoomScreen.tsx
+++ b/apps/web/src/features/draft/screens/DraftRoomScreen.tsx
@@ -79,7 +79,12 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
         ...cursor,
         avatarKey: cursor.avatarKey ?? pickDeterministicAvatarKey(cursor.label)
       }));
-  }, [cursorSpyUserEnabled, props.o.cursorSpy.cursors, props.o.cursorSpy.enabled, selfUserId]);
+  }, [
+    cursorSpyUserEnabled,
+    props.o.cursorSpy.cursors,
+    props.o.cursorSpy.enabled,
+    selfUserId
+  ]);
 
   const avatarKeyBySeat = useMemo(() => {
     const m = new Map<number, string | null>();

--- a/apps/web/src/features/draft/screens/DraftRoomScreen.tsx
+++ b/apps/web/src/features/draft/screens/DraftRoomScreen.tsx
@@ -49,6 +49,8 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
   const { colorScheme, setColorScheme } = useMantineColorScheme();
   const isMobile = useMediaQuery(`(max-width: ${FO_BP_MOBILE_MAX_PX}px)`);
   const isPreview = props.o.myRoster.pickDisabledReason === "Preview mode";
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [cursorSpyUserEnabled, setCursorSpyUserEnabled] = useState(true);
   const draftStatus = props.o.header.status ?? null;
   const isPre = draftStatus === "PENDING";
   const isPaused = draftStatus === "PAUSED";
@@ -70,14 +72,14 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
   );
   const selfUserId = Number(user?.sub);
   const remoteCursors = useMemo(() => {
-    if (!props.o.cursorSpy.enabled) return [];
+    if (!cursorSpyUserEnabled || !props.o.cursorSpy.enabled) return [];
     return props.o.cursorSpy.cursors
       .filter((cursor) => cursor.userId !== selfUserId)
       .map((cursor) => ({
         ...cursor,
         avatarKey: cursor.avatarKey ?? pickDeterministicAvatarKey(cursor.label)
       }));
-  }, [props.o.cursorSpy.cursors, props.o.cursorSpy.enabled, selfUserId]);
+  }, [cursorSpyUserEnabled, props.o.cursorSpy.cursors, props.o.cursorSpy.enabled, selfUserId]);
 
   const avatarKeyBySeat = useMemo(() => {
     const m = new Map<number, string | null>();
@@ -111,11 +113,11 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
       return;
     }
     const prev = prevIsMyTurnRef.current;
-    if (audioUnlocked && prev !== null && !prev && isMyTurn) {
+    if (soundEnabled && audioUnlocked && prev !== null && !prev && isMyTurn) {
       playTurnStartChime(audioControllerRef.current);
     }
     prevIsMyTurnRef.current = isMyTurn;
-  }, [audioControllerRef, audioUnlocked, draftStatus, isMyTurn, isPreview]);
+  }, [audioControllerRef, audioUnlocked, draftStatus, isMyTurn, isPreview, soundEnabled]);
 
   // Draft actions are available during live drafts when it's "my turn".
   // Note: `myRoster.canPick` is selection-dependent; we want click-to-confirm
@@ -136,7 +138,7 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
 
   const onDraftPointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      if (isMobile || !props.o.cursorSpy.enabled) return;
+      if (isMobile || !cursorSpyUserEnabled || !props.o.cursorSpy.enabled) return;
       const frame = frameRef.current;
       if (!frame) return;
       const rect = frame.getBoundingClientRect();
@@ -152,7 +154,7 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
         cursorEmitRafRef.current = window.requestAnimationFrame(flushCursorEmit);
       }
     },
-    [flushCursorEmit, isMobile, props.o.cursorSpy.enabled]
+    [cursorSpyUserEnabled, flushCursorEmit, isMobile, props.o.cursorSpy.enabled]
   );
 
   useEffect(() => {
@@ -219,22 +221,25 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
     () => mapDraftScreenCategories(props.o.pool.categories),
     [props.o.pool.categories]
   );
+  const isUndraftedOnly = props.o.header.poolMode === "UNDRAFTED_ONLY";
   const categories = useMemo(
     () =>
       categoriesRaw.map((c) => ({
         ...c,
         weightText: typeof c.weight === "number" ? formatSignedInt(c.weight) : null,
-        nominees: c.nominees.map((n) => {
-          const draftedMeta = draftedMetaByNominationId.get(Number(n.id));
-          return {
-            ...n,
-            draftedByLabel: draftedMeta?.draftedByLabel ?? null,
-            draftedByAvatarKey: draftedMeta?.draftedByAvatarKey ?? null,
-            draftedRoundPick: draftedMeta?.draftedRoundPick ?? null
-          };
-        })
+        nominees: c.nominees
+          .filter((n) => !isUndraftedOnly || !n.muted)
+          .map((n) => {
+            const draftedMeta = draftedMetaByNominationId.get(Number(n.id));
+            return {
+              ...n,
+              draftedByLabel: draftedMeta?.draftedByLabel ?? null,
+              draftedByAvatarKey: draftedMeta?.draftedByAvatarKey ?? null,
+              draftedRoundPick: draftedMeta?.draftedRoundPick ?? null
+            };
+          })
       })),
-    [categoriesRaw, draftedMetaByNominationId]
+    [categoriesRaw, draftedMetaByNominationId, isUndraftedOnly]
   );
   const nomineeById = useMemo(() => {
     const base = buildNomineeMetaById(categoriesRaw);
@@ -361,7 +366,12 @@ export function DraftRoomScreen(props: { o: DraftRoomOrchestration }) {
         onResumeDraft={props.o.header.onResumeDraft}
         audioController={audioControllerRef.current}
         audioUnlocked={audioUnlocked}
+        soundEnabled={soundEnabled}
+        onToggleSound={() => setSoundEnabled((v) => !v)}
         isMyTurn={isMyTurn}
+        showCursorSpyToggle={!isCompleted && !isPre}
+        cursorSpyUserEnabled={cursorSpyUserEnabled}
+        onToggleCursorSpy={() => setCursorSpyUserEnabled((v) => !v)}
         userLabel={previewUser.label}
         userAvatarKey={previewUser.avatarKey}
         onParticipantHoverSeat={setHoveredSeatNumber}

--- a/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
@@ -84,6 +84,11 @@ export function DraftHeaderMeasureRow(props: {
                   ]}
                   disabled={!props.canToggleView}
                 />
+                <Button type="button" variant="subtle" aria-hidden="true">
+                  <Text component="span" className="gicon" aria-hidden="true">
+                    volume_up
+                  </Text>
+                </Button>
               </Group>
 
               <Group className="drh-controlRow" gap="sm" wrap="nowrap">
@@ -95,22 +100,14 @@ export function DraftHeaderMeasureRow(props: {
                     <Box className="drh-togglePlaceholder" aria-hidden="true" />
                   )}
                 </Box>
+                {props.showCursorSpyToggle ? (
+                  <Button type="button" variant="subtle" aria-hidden="true">
+                    <Text component="span" className="gicon" aria-hidden="true">
+                      visibility
+                    </Text>
+                  </Button>
+                ) : null}
               </Group>
-            </Box>
-
-            <Box className="drh-controlsIcons">
-              <Button type="button" variant="subtle" aria-hidden="true">
-                <Text component="span" className="gicon" aria-hidden="true">
-                  volume_up
-                </Text>
-              </Button>
-              {props.showCursorSpyToggle ? (
-                <Button type="button" variant="subtle" aria-hidden="true">
-                  <Text component="span" className="gicon" aria-hidden="true">
-                    visibility
-                  </Text>
-                </Button>
-              ) : null}
             </Box>
           </Box>
         ) : null}

--- a/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
@@ -30,6 +30,7 @@ export function DraftHeaderMeasureRow(props: {
   showDraftedVisible: boolean;
   showDrafted: boolean;
   themeIcon: string;
+  showCursorSpyToggle: boolean;
   userLabel: string;
   userAvatarKey: string | null;
 }) {
@@ -100,6 +101,18 @@ export function DraftHeaderMeasureRow(props: {
         ) : null}
 
         <Group className="drh-stowaways" gap="xs" wrap="nowrap">
+          <Button type="button" variant="subtle" aria-hidden="true">
+            <Text component="span" className="gicon" aria-hidden="true">
+              volume_up
+            </Text>
+          </Button>
+          {props.showCursorSpyToggle ? (
+            <Button type="button" variant="subtle" aria-hidden="true">
+              <Text component="span" className="gicon" aria-hidden="true">
+                visibility
+              </Text>
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="subtle"

--- a/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
@@ -97,22 +97,25 @@ export function DraftHeaderMeasureRow(props: {
                 </Box>
               </Group>
             </Box>
+
+            <Box className="drh-controlsIcons">
+              <Button type="button" variant="subtle" aria-hidden="true">
+                <Text component="span" className="gicon" aria-hidden="true">
+                  volume_up
+                </Text>
+              </Button>
+              {props.showCursorSpyToggle ? (
+                <Button type="button" variant="subtle" aria-hidden="true">
+                  <Text component="span" className="gicon" aria-hidden="true">
+                    visibility
+                  </Text>
+                </Button>
+              ) : null}
+            </Box>
           </Box>
         ) : null}
 
         <Group className="drh-stowaways" gap="xs" wrap="nowrap">
-          <Button type="button" variant="subtle" aria-hidden="true">
-            <Text component="span" className="gicon" aria-hidden="true">
-              volume_up
-            </Text>
-          </Button>
-          {props.showCursorSpyToggle ? (
-            <Button type="button" variant="subtle" aria-hidden="true">
-              <Text component="span" className="gicon" aria-hidden="true">
-                visibility
-              </Text>
-            </Button>
-          ) : null}
           <Button
             type="button"
             variant="subtle"

--- a/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
@@ -72,42 +72,40 @@ export function DraftHeaderMeasureRow(props: {
         {props.showDraftControls ? (
           <Box className="drh-controls">
             <Box className="drh-controlsGrid">
-              <Group className="drh-controlRow" gap="sm" wrap="nowrap">
-                <Text className="drh-label">View</Text>
-                <SegmentedControl
-                  size="xs"
-                  value={props.view}
-                  onChange={() => {}}
-                  data={[
-                    { value: "draft", label: "Draft" },
-                    { value: "roster", label: "Roster" }
-                  ]}
-                  disabled={!props.canToggleView}
-                />
+              <Text className="drh-label">View</Text>
+              <SegmentedControl
+                size="xs"
+                value={props.view}
+                onChange={() => {}}
+                data={[
+                  { value: "draft", label: "Draft" },
+                  { value: "roster", label: "Roster" }
+                ]}
+                disabled={!props.canToggleView}
+              />
+              <Button type="button" variant="subtle" aria-hidden="true">
+                <Text component="span" className="gicon" aria-hidden="true">
+                  volume_up
+                </Text>
+              </Button>
+
+              <Text className="drh-label">Show drafted</Text>
+              <Box className="drh-toggleSlot">
+                {props.showDraftedVisible ? (
+                  <Switch size="sm" checked={props.showDrafted} onChange={() => {}} />
+                ) : (
+                  <Box className="drh-togglePlaceholder" aria-hidden="true" />
+                )}
+              </Box>
+              {props.showCursorSpyToggle ? (
                 <Button type="button" variant="subtle" aria-hidden="true">
                   <Text component="span" className="gicon" aria-hidden="true">
-                    volume_up
+                    visibility
                   </Text>
                 </Button>
-              </Group>
-
-              <Group className="drh-controlRow" gap="sm" wrap="nowrap">
-                <Text className="drh-label">Show drafted</Text>
-                <Box className="drh-toggleSlot">
-                  {props.showDraftedVisible ? (
-                    <Switch size="sm" checked={props.showDrafted} onChange={() => {}} />
-                  ) : (
-                    <Box className="drh-togglePlaceholder" aria-hidden="true" />
-                  )}
-                </Box>
-                {props.showCursorSpyToggle ? (
-                  <Button type="button" variant="subtle" aria-hidden="true">
-                    <Text component="span" className="gicon" aria-hidden="true">
-                      visibility
-                    </Text>
-                  </Button>
-                ) : null}
-              </Group>
+              ) : (
+                <Box />
+              )}
             </Box>
           </Box>
         ) : null}

--- a/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderMeasureRow.tsx
@@ -72,30 +72,34 @@ export function DraftHeaderMeasureRow(props: {
         {props.showDraftControls ? (
           <Box className="drh-controls">
             <Box className="drh-controlsGrid">
-              <Text className="drh-label">View</Text>
-              <SegmentedControl
-                size="xs"
-                value={props.view}
-                onChange={() => {}}
-                data={[
-                  { value: "draft", label: "Draft" },
-                  { value: "roster", label: "Roster" }
-                ]}
-                disabled={!props.canToggleView}
-              />
+              <Box className="drh-controlRow">
+                <Text className="drh-label">View</Text>
+                <SegmentedControl
+                  size="xs"
+                  value={props.view}
+                  onChange={() => {}}
+                  data={[
+                    { value: "draft", label: "Draft" },
+                    { value: "roster", label: "Roster" }
+                  ]}
+                  disabled={!props.canToggleView}
+                />
+              </Box>
               <Button type="button" variant="subtle" aria-hidden="true">
                 <Text component="span" className="gicon" aria-hidden="true">
                   volume_up
                 </Text>
               </Button>
 
-              <Text className="drh-label">Show drafted</Text>
-              <Box className="drh-toggleSlot">
-                {props.showDraftedVisible ? (
-                  <Switch size="sm" checked={props.showDrafted} onChange={() => {}} />
-                ) : (
-                  <Box className="drh-togglePlaceholder" aria-hidden="true" />
-                )}
+              <Box className="drh-controlRow">
+                <Text className="drh-label">Show drafted</Text>
+                <Box className="drh-toggleSlot">
+                  {props.showDraftedVisible ? (
+                    <Switch size="sm" checked={props.showDrafted} onChange={() => {}} />
+                  ) : (
+                    <Box className="drh-togglePlaceholder" aria-hidden="true" />
+                  )}
+                </Box>
               </Box>
               {props.showCursorSpyToggle ? (
                 <Button type="button" variant="subtle" aria-hidden="true">

--- a/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
@@ -69,17 +69,19 @@ export function DraftHeaderRightWing(props: {
       {!compactHeader && props.showDraftControls ? (
         <Box className="drh-controls">
           <Box className="drh-controlsGrid">
-            <Text className="drh-label">View</Text>
-            <SegmentedControl
-              size="xs"
-              value={props.view}
-              onChange={(v) => props.onViewChange(v as "draft" | "roster")}
-              data={[
-                { value: "draft", label: "Draft" },
-                { value: "roster", label: "Roster" }
-              ]}
-              disabled={!props.canToggleView}
-            />
+            <Box className="drh-controlRow">
+              <Text className="drh-label">View</Text>
+              <SegmentedControl
+                size="xs"
+                value={props.view}
+                onChange={(v) => props.onViewChange(v as "draft" | "roster")}
+                data={[
+                  { value: "draft", label: "Draft" },
+                  { value: "roster", label: "Roster" }
+                ]}
+                disabled={!props.canToggleView}
+              />
+            </Box>
             <Tooltip
               label={props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
               position="bottom"
@@ -97,17 +99,19 @@ export function DraftHeaderRightWing(props: {
               </Button>
             </Tooltip>
 
-            <Text className="drh-label">Show drafted</Text>
-            <Box className="drh-toggleSlot">
-              {props.showDraftedVisible ? (
-                <Switch
-                  size="sm"
-                  checked={props.showDrafted}
-                  onChange={(e) => props.onToggleShowDrafted(e.currentTarget.checked)}
-                />
-              ) : (
-                <Box className="drh-togglePlaceholder" aria-hidden="true" />
-              )}
+            <Box className="drh-controlRow">
+              <Text className="drh-label">Show drafted</Text>
+              <Box className="drh-toggleSlot">
+                {props.showDraftedVisible ? (
+                  <Switch
+                    size="sm"
+                    checked={props.showDrafted}
+                    onChange={(e) => props.onToggleShowDrafted(e.currentTarget.checked)}
+                  />
+                ) : (
+                  <Box className="drh-togglePlaceholder" aria-hidden="true" />
+                )}
+              </Box>
             </Box>
             {props.showCursorSpyToggle ? (
               <Tooltip

--- a/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
@@ -25,6 +25,11 @@ export function DraftHeaderRightWing(props: {
   showDraftedVisible: boolean;
   themeIcon: string;
   onToggleTheme: () => void;
+  soundEnabled: boolean;
+  onToggleSound: () => void;
+  showCursorSpyToggle: boolean;
+  cursorSpyUserEnabled: boolean;
+  onToggleCursorSpy: () => void;
   onStartDraft: () => void;
   onPauseDraft: () => void;
   onResumeDraft: () => void;
@@ -114,6 +119,30 @@ export function DraftHeaderRightWing(props: {
               <Menu.Item
                 leftSection={
                   <Text component="span" className="gicon" aria-hidden="true">
+                    {props.soundEnabled ? "volume_up" : "volume_off"}
+                  </Text>
+                }
+                onClick={props.onToggleSound}
+              >
+                {props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
+              </Menu.Item>
+
+              {props.showCursorSpyToggle ? (
+                <Menu.Item
+                  leftSection={
+                    <Text component="span" className="gicon" aria-hidden="true">
+                      {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
+                    </Text>
+                  }
+                  onClick={props.onToggleCursorSpy}
+                >
+                  {props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+                </Menu.Item>
+              ) : null}
+
+              <Menu.Item
+                leftSection={
+                  <Text component="span" className="gicon" aria-hidden="true">
                     {props.themeIcon}
                   </Text>
                 }
@@ -154,6 +183,28 @@ export function DraftHeaderRightWing(props: {
         </Group>
       ) : (
         <Group className="drh-stowaways" gap="xs" wrap="nowrap">
+          <Button
+            type="button"
+            variant="subtle"
+            onClick={props.onToggleSound}
+            aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
+          >
+            <Text component="span" className="gicon" aria-hidden="true">
+              {props.soundEnabled ? "volume_up" : "volume_off"}
+            </Text>
+          </Button>
+          {props.showCursorSpyToggle ? (
+            <Button
+              type="button"
+              variant="subtle"
+              onClick={props.onToggleCursorSpy}
+              aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+            >
+              <Text component="span" className="gicon" aria-hidden="true">
+                {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
+              </Text>
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="subtle"

--- a/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
@@ -69,68 +69,66 @@ export function DraftHeaderRightWing(props: {
       {!compactHeader && props.showDraftControls ? (
         <Box className="drh-controls">
           <Box className="drh-controlsGrid">
-            <Group className="drh-controlRow" gap="sm" wrap="nowrap">
-              <Text className="drh-label">View</Text>
-              <SegmentedControl
-                size="xs"
-                value={props.view}
-                onChange={(v) => props.onViewChange(v as "draft" | "roster")}
-                data={[
-                  { value: "draft", label: "Draft" },
-                  { value: "roster", label: "Roster" }
-                ]}
-                disabled={!props.canToggleView}
-              />
+            <Text className="drh-label">View</Text>
+            <SegmentedControl
+              size="xs"
+              value={props.view}
+              onChange={(v) => props.onViewChange(v as "draft" | "roster")}
+              data={[
+                { value: "draft", label: "Draft" },
+                { value: "roster", label: "Roster" }
+              ]}
+              disabled={!props.canToggleView}
+            />
+            <Tooltip
+              label={props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
+              position="bottom"
+              withArrow
+            >
+              <Button
+                type="button"
+                variant="subtle"
+                onClick={props.onToggleSound}
+                aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
+              >
+                <Text component="span" className="gicon" aria-hidden="true">
+                  {props.soundEnabled ? "volume_up" : "volume_off"}
+                </Text>
+              </Button>
+            </Tooltip>
+
+            <Text className="drh-label">Show drafted</Text>
+            <Box className="drh-toggleSlot">
+              {props.showDraftedVisible ? (
+                <Switch
+                  size="sm"
+                  checked={props.showDrafted}
+                  onChange={(e) => props.onToggleShowDrafted(e.currentTarget.checked)}
+                />
+              ) : (
+                <Box className="drh-togglePlaceholder" aria-hidden="true" />
+              )}
+            </Box>
+            {props.showCursorSpyToggle ? (
               <Tooltip
-                label={props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
+                label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
                 position="bottom"
                 withArrow
               >
                 <Button
                   type="button"
                   variant="subtle"
-                  onClick={props.onToggleSound}
-                  aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
+                  onClick={props.onToggleCursorSpy}
+                  aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
                 >
                   <Text component="span" className="gicon" aria-hidden="true">
-                    {props.soundEnabled ? "volume_up" : "volume_off"}
+                    {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
                   </Text>
                 </Button>
               </Tooltip>
-            </Group>
-
-            <Group className="drh-controlRow" gap="sm" wrap="nowrap">
-              <Text className="drh-label">Show drafted</Text>
-              <Box className="drh-toggleSlot">
-                {props.showDraftedVisible ? (
-                  <Switch
-                    size="sm"
-                    checked={props.showDrafted}
-                    onChange={(e) => props.onToggleShowDrafted(e.currentTarget.checked)}
-                  />
-                ) : (
-                  <Box className="drh-togglePlaceholder" aria-hidden="true" />
-                )}
-              </Box>
-              {props.showCursorSpyToggle ? (
-                <Tooltip
-                  label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
-                  position="bottom"
-                  withArrow
-                >
-                  <Button
-                    type="button"
-                    variant="subtle"
-                    onClick={props.onToggleCursorSpy}
-                    aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
-                  >
-                    <Text component="span" className="gicon" aria-hidden="true">
-                      {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
-                    </Text>
-                  </Button>
-                </Tooltip>
-              ) : null}
-            </Group>
+            ) : (
+              <Box />
+            )}
           </Box>
         </Box>
       ) : null}

--- a/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
@@ -6,6 +6,7 @@ import {
   SegmentedControl,
   Switch,
   Text,
+  Tooltip,
   UnstyledButton
 } from "@ui";
 import { AnimalAvatarIcon } from "@/shared/animalAvatarIcon";
@@ -97,6 +98,43 @@ export function DraftHeaderRightWing(props: {
               </Box>
             </Group>
           </Box>
+
+          <Box className="drh-controlsIcons">
+            <Tooltip
+              label={props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
+              position="bottom"
+              withArrow
+            >
+              <Button
+                type="button"
+                variant="subtle"
+                onClick={props.onToggleSound}
+                aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
+              >
+                <Text component="span" className="gicon" aria-hidden="true">
+                  {props.soundEnabled ? "volume_up" : "volume_off"}
+                </Text>
+              </Button>
+            </Tooltip>
+            {props.showCursorSpyToggle ? (
+              <Tooltip
+                label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+                position="bottom"
+                withArrow
+              >
+                <Button
+                  type="button"
+                  variant="subtle"
+                  onClick={props.onToggleCursorSpy}
+                  aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+                >
+                  <Text component="span" className="gicon" aria-hidden="true">
+                    {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
+                  </Text>
+                </Button>
+              </Tooltip>
+            ) : null}
+          </Box>
         </Box>
       ) : null}
 
@@ -183,28 +221,6 @@ export function DraftHeaderRightWing(props: {
         </Group>
       ) : (
         <Group className="drh-stowaways" gap="xs" wrap="nowrap">
-          <Button
-            type="button"
-            variant="subtle"
-            onClick={props.onToggleSound}
-            aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
-          >
-            <Text component="span" className="gicon" aria-hidden="true">
-              {props.soundEnabled ? "volume_up" : "volume_off"}
-            </Text>
-          </Button>
-          {props.showCursorSpyToggle ? (
-            <Button
-              type="button"
-              variant="subtle"
-              onClick={props.onToggleCursorSpy}
-              aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
-            >
-              <Text component="span" className="gicon" aria-hidden="true">
-                {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
-              </Text>
-            </Button>
-          ) : null}
           <Button
             type="button"
             variant="subtle"

--- a/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
@@ -81,6 +81,22 @@ export function DraftHeaderRightWing(props: {
                 ]}
                 disabled={!props.canToggleView}
               />
+              <Tooltip
+                label={props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
+                position="bottom"
+                withArrow
+              >
+                <Button
+                  type="button"
+                  variant="subtle"
+                  onClick={props.onToggleSound}
+                  aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
+                >
+                  <Text component="span" className="gicon" aria-hidden="true">
+                    {props.soundEnabled ? "volume_up" : "volume_off"}
+                  </Text>
+                </Button>
+              </Tooltip>
             </Group>
 
             <Group className="drh-controlRow" gap="sm" wrap="nowrap">
@@ -96,44 +112,25 @@ export function DraftHeaderRightWing(props: {
                   <Box className="drh-togglePlaceholder" aria-hidden="true" />
                 )}
               </Box>
-            </Group>
-          </Box>
-
-          <Box className="drh-controlsIcons">
-            <Tooltip
-              label={props.soundEnabled ? "Mute sounds" : "Unmute sounds"}
-              position="bottom"
-              withArrow
-            >
-              <Button
-                type="button"
-                variant="subtle"
-                onClick={props.onToggleSound}
-                aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
-              >
-                <Text component="span" className="gicon" aria-hidden="true">
-                  {props.soundEnabled ? "volume_up" : "volume_off"}
-                </Text>
-              </Button>
-            </Tooltip>
-            {props.showCursorSpyToggle ? (
-              <Tooltip
-                label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
-                position="bottom"
-                withArrow
-              >
-                <Button
-                  type="button"
-                  variant="subtle"
-                  onClick={props.onToggleCursorSpy}
-                  aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+              {props.showCursorSpyToggle ? (
+                <Tooltip
+                  label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+                  position="bottom"
+                  withArrow
                 >
-                  <Text component="span" className="gicon" aria-hidden="true">
-                    {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
-                  </Text>
-                </Button>
-              </Tooltip>
-            ) : null}
+                  <Button
+                    type="button"
+                    variant="subtle"
+                    onClick={props.onToggleCursorSpy}
+                    aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+                  >
+                    <Text component="span" className="gicon" aria-hidden="true">
+                      {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}
+                    </Text>
+                  </Button>
+                </Tooltip>
+              ) : null}
+            </Group>
           </Box>
         </Box>
       ) : null}

--- a/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
+++ b/apps/web/src/features/draft/ui/DraftHeaderRightWing.tsx
@@ -91,7 +91,9 @@ export function DraftHeaderRightWing(props: {
                 type="button"
                 variant="subtle"
                 onClick={props.onToggleSound}
-                aria-label={props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"}
+                aria-label={
+                  props.soundEnabled ? "Mute draft sounds" : "Unmute draft sounds"
+                }
               >
                 <Text component="span" className="gicon" aria-hidden="true">
                   {props.soundEnabled ? "volume_up" : "volume_off"}
@@ -123,7 +125,9 @@ export function DraftHeaderRightWing(props: {
                   type="button"
                   variant="subtle"
                   onClick={props.onToggleCursorSpy}
-                  aria-label={props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"}
+                  aria-label={
+                    props.cursorSpyUserEnabled ? "Hide cursor spy" : "Show cursor spy"
+                  }
                 >
                   <Text component="span" className="gicon" aria-hidden="true">
                     {props.cursorSpyUserEnabled ? "visibility" : "visibility_off"}

--- a/apps/web/src/orchestration/draft/orchestration.ts
+++ b/apps/web/src/orchestration/draft/orchestration.ts
@@ -229,6 +229,7 @@ export type DraftRoomOrchestration = {
 export function useDraftRoomOrchestration(args: {
   initialDraftId?: string | number;
   disabled?: boolean;
+  disableCursorSpy?: boolean;
 }): DraftRoomOrchestration {
   const { initialDraftId, disabled } = args;
 
@@ -585,7 +586,9 @@ export function useDraftRoomOrchestration(args: {
   }, [loadSnapshot, snapshot]);
 
   const draftStatus = snapshot?.draft.status ?? null;
-  const cursorSpyEnabled = draftStatus === "IN_PROGRESS" || draftStatus === "PAUSED";
+  const cursorSpyEnabled =
+    !args.disableCursorSpy &&
+    (draftStatus === "IN_PROGRESS" || draftStatus === "PAUSED");
 
   const upsertRemoteCursor = useCallback(
     (cursor: { userId: number; x: number; y: number; ts: number }) => {
@@ -765,8 +768,7 @@ export function useDraftRoomOrchestration(args: {
     return categories.map((c) => {
       const rows = nominationsByCategoryId.get(c.id) ?? [];
       const active = rows.filter((n) => n.status === "ACTIVE");
-      const filtered =
-        poolMode === "UNDRAFTED_ONLY" ? active.filter((n) => !drafted.has(n.id)) : active;
+      const filtered = active;
       const icon = iconByCategoryId.get(c.id) ?? "";
       const nominations = filtered.map((n) => {
         const isDrafted = drafted.has(n.id);
@@ -822,7 +824,7 @@ export function useDraftRoomOrchestration(args: {
           performerProfilePath:
             (n as { performer_profile_path?: string | null }).performer_profile_path ??
             null,
-          muted: poolMode === "ALL_MUTED" && isDrafted,
+          muted: isDrafted,
           selected: selectedNominationId === n.id,
           winner: winnerSet.has(n.id)
         };

--- a/apps/web/src/orchestration/draft/orchestration.ts
+++ b/apps/web/src/orchestration/draft/orchestration.ts
@@ -587,8 +587,7 @@ export function useDraftRoomOrchestration(args: {
 
   const draftStatus = snapshot?.draft.status ?? null;
   const cursorSpyEnabled =
-    !args.disableCursorSpy &&
-    (draftStatus === "IN_PROGRESS" || draftStatus === "PAUSED");
+    !args.disableCursorSpy && (draftStatus === "IN_PROGRESS" || draftStatus === "PAUSED");
 
   const upsertRemoteCursor = useCallback(
     (cursor: { userId: number; x: number; y: number; ts: number }) => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1010,25 +1010,11 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
   gap: var(--fo-db-headerRight-gap);
 }
 
-.drh-controls {
-  display: flex;
-  align-items: center;
-  gap: var(--fo-space-xs);
-}
-
 .drh-controlsGrid {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--fo-space-dense-1);
-}
-
-.drh-controlsIcons {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-around;
-  align-self: stretch;
 }
 
 .drh-label {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1041,7 +1041,6 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
   justify-content: flex-end;
 }
 
-
 .drh-togglePlaceholder {
   height: calc(var(--fo-space-8) + var(--fo-space-dense-2) + var(--fo-space-4));
   opacity: var(--fo-alpha-00);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1010,7 +1010,20 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
   gap: var(--fo-db-headerRight-gap);
 }
 
+.drh-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--fo-space-xs);
+}
+
 .drh-controlsGrid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--fo-space-dense-1);
+}
+
+.drh-controlsIcons {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1011,10 +1011,11 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
 }
 
 .drh-controlsGrid {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: auto auto auto;
   align-items: center;
-  gap: var(--fo-space-dense-1);
+  column-gap: var(--mantine-spacing-sm);
+  row-gap: var(--fo-space-dense-1);
 }
 
 .drh-label {
@@ -1031,10 +1032,6 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
   justify-content: flex-end;
 }
 
-.drh-controlRow {
-  width: 100%;
-  justify-content: center;
-}
 
 .drh-togglePlaceholder {
   height: calc(var(--fo-space-8) + var(--fo-space-dense-2) + var(--fo-space-4));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1027,7 +1027,8 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--fo-space-dense-1);
+  justify-content: space-around;
+  align-self: stretch;
 }
 
 .drh-label {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1012,10 +1012,19 @@ body[data-mantine-color-scheme="dark"] .drh-token.is-active {
 
 .drh-controlsGrid {
   display: grid;
-  grid-template-columns: auto auto auto;
+  grid-template-columns: auto auto;
   align-items: center;
+  justify-items: center;
   column-gap: var(--mantine-spacing-sm);
   row-gap: var(--fo-space-dense-1);
+}
+
+.drh-controlRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--mantine-spacing-sm);
+  justify-self: stretch;
 }
 
 .drh-label {


### PR DESCRIPTION
## Summary

- **Sound toggle**: Adds a `volume_up`/`volume_off` icon button to the draft board header right wing (both non-compact stowaways and compact settings menu); gates turn-start chime and countdown beep on the toggle state
- **Cursor spy toggle**: Adds a `visibility`/`visibility_off` icon button in the same locations; gates remote cursor rendering and cursor position emission; toggle is only shown when the draft is active (not pre/completed); not shown on mobile
- **Mobile cursor spy disabled**: Passes `disableCursorSpy: isMobile` from `DraftRoomPage` to the orchestration, disabling the cursor spy TTL interval, socket processing, and emission entirely on mobile
- **Tooltip bug fix**: Removes the `UNDRAFTED_ONLY` nominee filter from the orchestration's `poolCategories` computation so `nomineeById` always contains all active nominees (including drafted ones); moves display filtering to `DraftRoomScreen`'s `categories` useMemo — this restores rail tooltips (ledger, roster, autodraft) for drafted nominees when "Show drafted" is off
- **Measurement accuracy**: Updates `DraftHeaderMeasureRow` with matching placeholder buttons so the hidden measurement wing accurately reflects the actual non-compact right wing width

## Test plan

- [ ] Sound toggle button appears in the header; clicking mutes/unmutes the turn-start chime and countdown beep
- [ ] Cursor spy toggle appears during an in-progress or paused draft; clicking hides/shows remote cursors and stops/starts emission
- [ ] Cursor spy toggle is hidden before draft starts and after it completes
- [ ] On a mobile viewport, no cursor ghost avatars appear and no cursor position events are emitted
- [ ] With "Show drafted" off (`UNDRAFTED_ONLY`), hovering a drafted nominee in the ledger/roster/autodraft rails shows the film tooltip correctly
- [ ] Compact header (narrow viewport) collapses controls into settings menu; sound and cursor spy items appear there as expected
- [ ] TypeScript typecheck passes; all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)